### PR TITLE
Improve build: LDFLAGS

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -173,27 +173,27 @@ THIN_RMAP_OBJECTS=$(subst .cc,.o,$(THIN_RMAP_SOURCE))
 
 thin_debug: $(THIN_DEBUG_OBJECTS) thin-provisioning/thin_debug.o
 	@echo "    [LD]  $@"
-	$(V) $(CXX) $(CXXFLAGS) -o $@ $+ $(LIBS) $(LIBEXPAT)
+	$(V) $(CXX) $(CXXFLAGS) $(LDFLAGS) -o $@ $+ $(LIBS) $(LIBEXPAT)
 
 thin_repair: $(THIN_REPAIR_OBJECTS) thin-provisioning/thin_repair.o
 	@echo "    [LD]  $@"
-	$(V) $(CXX) $(CXXFLAGS) -o $@ $+ $(LIBS) $(LIBEXPAT)
+	$(V) $(CXX) $(CXXFLAGS) $(LDFLAGS) -o $@ $+ $(LIBS) $(LIBEXPAT)
 
 thin_dump: $(THIN_DUMP_OBJECTS) thin-provisioning/thin_dump.o
 	@echo "    [LD]  $@"
-	$(V) $(CXX) $(CXXFLAGS) -o $@ $+ $(LIBS) $(LIBEXPAT)
+	$(V) $(CXX) $(CXXFLAGS) $(LDFLAGS) -o $@ $+ $(LIBS) $(LIBEXPAT)
 
 thin_restore: $(THIN_RESTORE_OBJECTS) thin-provisioning/thin_restore.o
 	@echo "    [LD]  $@"
-	$(V) $(CXX) $(CXXFLAGS) -o $@ $+ $(LIBS) $(LIBEXPAT)
+	$(V) $(CXX) $(CXXFLAGS) $(LDFLAGS) -o $@ $+ $(LIBS) $(LIBEXPAT)
 
 thin_check: $(THIN_CHECK_OBJECTS) thin-provisioning/thin_check.o
 	@echo "    [LD]  $@"
-	$(V) $(CXX) $(CXXFLAGS) -o $@ $+ $(LIBS)
+	$(V) $(CXX) $(CXXFLAGS) $(LDFLAGS) -o $@ $+ $(LIBS)
 
 thin_rmap: $(THIN_RMAP_OBJECTS) thin-provisioning/thin_rmap.o
 	@echo "    [LD]  $@"
-	$(V) $(CXX) $(CXXFLAGS) -o $@ $+ $(LIBS)
+	$(V) $(CXX) $(CXXFLAGS) $(LDFLAGS) -o $@ $+ $(LIBS)
 
 #----------------------------------------------------------------
 # Cache tools
@@ -216,7 +216,7 @@ CACHE_CHECK_OBJECTS=$(subst .cc,.o,$(CACHE_CHECK_SOURCE))
 
 cache_check: $(CACHE_CHECK_OBJECTS) cache/check.o
 	@echo "    [LD]  $@"
-	$(V) $(CXX) $(CXXFLAGS) -o $@ $+ $(LIBS)
+	$(V) $(CXX) $(CXXFLAGS) $(LDFLAGS) -o $@ $+ $(LIBS)
 
 DEPEND_FILES=\
 	$(subst .cc,.d,$(SOURCE)) \

--- a/unit-tests/Makefile.in
+++ b/unit-tests/Makefile.in
@@ -79,7 +79,7 @@ TEST_OBJECTS=$(subst .cc,.gmo,$(TEST_SOURCE))
 
 unit-tests/unit_tests: $(TEST_OBJECTS) lib/libgmock.a lib/libpdata.a
 	@echo "    [LD]  $<"
-	$(V)g++ $(CXXFLAGS) -o $@ $(TEST_OBJECTS) $(LIBS) $(GMOCK_LIBS) $(LIBEXPAT)
+	$(V)g++ $(CXXFLAGS) $(LDFLAGS) -o $@ $(TEST_OBJECTS) $(LIBS) $(GMOCK_LIBS) $(LIBEXPAT)
 
 .PHONEY: unit-test
 


### PR DESCRIPTION
Linker must be passed LDFLAGS for some distributions, as CXXFLAGS should
not normally contain any linker flags (may fail if passed to
compile-only invocations).

Signed-off-by: Robin H. Johnson robbat2@gentoo.org
