### PR TITLE
use persistent-data::bitset to avoid ambiguity

### DIFF
--- a/caching/cache_check.cc
+++ b/caching/cache_check.cc
@@ -254,7 +254,7 @@ namespace {
 				out << "examining discard bitset" << end_message();
 				{
 					nested_output::nest _ = out.push();
-					bitset discards(tm, sb.discard_root, sb.discard_nr_blocks);
+					persistent_data::bitset discards(tm, sb.discard_root, sb.discard_nr_blocks);
 				}
 			}
 		}

--- a/caching/metadata.cc
+++ b/caching/metadata.cc
@@ -79,7 +79,7 @@ metadata::create_metadata(block_manager<>::ptr bm)
 	// We can't instantiate the hint array yet, since we don't know the
 	// hint width.
 
-	discard_bits_ = bitset::ptr(new bitset(tm_));
+	discard_bits_ = persistent_data::bitset::ptr(new persistent_data::bitset(tm_));
 }
 
 void
@@ -100,8 +100,8 @@ metadata::open_metadata(block_manager<>::ptr bm)
 				       sb_.hint_root, sb_.cache_blocks));
 
 	if (sb_.discard_root)
-		discard_bits_ = bitset::ptr(
-			new bitset(tm_, sb_.discard_root, sb_.discard_nr_blocks));
+		discard_bits_ = persistent_data::bitset::ptr(
+			new persistent_data::bitset(tm_, sb_.discard_root, sb_.discard_nr_blocks));
 }
 
 void

--- a/caching/metadata.h
+++ b/caching/metadata.h
@@ -38,7 +38,7 @@ namespace caching {
 		checked_space_map::ptr metadata_sm_;
 		mapping_array::ptr mappings_;
 		hint_array::ptr hints_;
-		bitset::ptr discard_bits_;
+		persistent_data::bitset::ptr discard_bits_;
 
 	private:
 		void init_superblock();

--- a/persistent-data/data-structures/bitset.cc
+++ b/persistent-data/data-structures/bitset.cc
@@ -198,54 +198,54 @@ namespace persistent_data {
 
 //----------------------------------------------------------------
 
-bitset::bitset(tm_ptr tm)
+persistent_data::bitset::bitset(tm_ptr tm)
 	: impl_(new bitset_impl(tm))
 {
 }
 
-bitset::bitset(tm_ptr tm, block_address root, unsigned nr_bits)
+persistent_data::bitset::bitset(tm_ptr tm, block_address root, unsigned nr_bits)
 	: impl_(new bitset_impl(tm, root, nr_bits))
 {
 }
 
 block_address
-bitset::get_root() const
+persistent_data::bitset::get_root() const
 {
 	return impl_->get_root();
 }
 
 void
-bitset::grow(unsigned new_nr_bits, bool default_value)
+persistent_data::bitset::grow(unsigned new_nr_bits, bool default_value)
 {
 	impl_->grow(new_nr_bits, default_value);
 }
 
 void
-bitset::destroy()
+persistent_data::bitset::destroy()
 {
 	impl_->destroy();
 }
 
 bool
-bitset::get(unsigned n)
+persistent_data::bitset::get(unsigned n)
 {
 	return impl_->get(n);
 }
 
 void
-bitset::set(unsigned n, bool value)
+persistent_data::bitset::set(unsigned n, bool value)
 {
 	impl_->set(n, value);
 }
 
 void
-bitset::flush()
+persistent_data::bitset::flush()
 {
 	impl_->flush();
 }
 
 void
-bitset::walk_bitset(bitset_visitor &v) const
+persistent_data::bitset::walk_bitset(bitset_visitor &v) const
 {
 	impl_->walk_bitset(v);
 }


### PR DESCRIPTION
thin-provisioning-tools does not currently compile with boost-1.55.0 (gcc-4.8.2): there is a conflict between persistent_data::bitset and std::bitset.  my bitset-bug branch provides a patch that makes it compile again: it simply adds the prefix persistent_data:: in a few places to lift the ambiguity.
