### PR TITLE
thin_metadata_size: Fix long names of units

### DIFF
--- a/man8/thin_metadata_size.8
+++ b/man8/thin_metadata_size.8
@@ -15,13 +15,13 @@ Because thin provisioning pools are holding widely variable contents,
 this tool is needed to provide sensible initial default size.
 
 .IP "\fB\-b, \-\-block-size\fP \fIBLOCKSIZE[bskKmMgGtTpPeEzZyY]\fP"
-Block size of thin provisioned devices in units of bytes,sectors,kilobytes,kibibytes,... respectively.
+Block size of thin provisioned devices in units of bytes, sectors, kibibytes, kilobytes, ... respectively.
 Default is in sectors without a block size unit specifier.
 Size/number option arguments can be followed by unit specifiers in short one character
-and long form (eg. -b1m or -b1megabytes).
+and long form (eg. -b1m or -b1mebibytes).
 
 .IP "\fB\-s, \-\-pool-size\fP \fIPOOLSIZE[bskKmMgGtTpPeEzZyY]\fP"
-Thin provisioning pool size in units of bytes,sectors,kilobytes,kibibytes,... respectively.
+Thin provisioning pool size in units of bytes, sectors, kibibytes, kilobytes, ... respectively.
 Default is in sectors without a pool size unit specifier.
 
 .IP "\fB\-m, \-\-max-thins\fP \fI#[bskKmMgGtTpPeEzZyY]\fP"
@@ -30,7 +30,7 @@ Unit identifier supported to allow for convenient entry of large quantities, eg.
 Default is absolute quantity without a number unit specifier.
 
 .IP "\fB\-u, \-\-unit\fP \fI{bskKmMgGtTpPeEzZyY}\fP"
-Output unit specifier in units of bytes,sectors,kilobytes,kibibytes,... respectively.
+Output unit specifier in units of bytes, sectors, kibibytes, kilobytes, ... respectively.
 Default is in sectors without an output unit specifier.
 
 .IP "\fB\-n, \-\-numeric-only [short|long]\fP"
@@ -43,24 +43,24 @@ Print help and exit.
 Output version information and exit.
 
 .SH EXAMPLES
-Calculates the thin provisioning metadata device size for block size 64 kilobytes,
-pool size 1 terabytes and maximum number of thin provisioned devices and snapshots of 1000
+Calculates the thin provisioning metadata device size for block size 64 kibibytes,
+pool size 1 tebibytes and maximum number of thin provisioned devices and snapshots of 1000
 in units of sectors with long output:
 .sp
 .B thin_metadata_size -b64k -s1t -m1000
 
-Or (using the long options instead) for block size 1 gigabyte, pool size 1 petabytes and maximum number of thin provisioned devices
-and snapshots of 1 million with numeric only output in units of gigabytes:
+Or (using the long options instead) for block size 1 gibibyte, pool size 1 petabyte and maximum number of thin provisioned devices
+and snapshots of 1 million with numeric-only output in units of gigabytes:
 .sp
-.B thin_metadata_size --block-size=1g --pool-size=1p --max-thins=1M --unit=g --numeric-only
+.B thin_metadata_size --block-size=1g --pool-size=1P --max-thins=1M --unit=G --numeric-only
 
-Same as before (1g,1p,1M,numeric-only) but with unit specifier character appended:
+Same as before (1g, 1P, 1M, numeric-only) but with unit specifier character appended:
 .sp
-.B thin_metadata_size --block-size=1giga --pool-size=1petabytes --max-thins=1mebi --unit=g --numeric-only=short
+.B thin_metadata_size --block-size=1gibi --pool-size=1petabytes --max-thins=1mega --unit=G --numeric-only=short
 
 Or with unit specifier string appended:
 .sp
-.B thin_metadata_size --block-size=1giga --pool-size=1petabytes --max-thins=1mebi --unit=g -nlong
+.B thin_metadata_size --block-size=1gibi --pool-size=1petabytes --max-thins=1mega --unit=G -nlong
 
 .SH DIAGNOSTICS
 .B thin_metadata_size

--- a/thin-provisioning/thin_metadata_size.c
+++ b/thin-provisioning/thin_metadata_size.c
@@ -111,10 +111,10 @@ static struct global *init_prg(char *prg_path)
 	unsigned u;
 	static char *unit_chars = "bskKmMgGtTpPeEzZyY";
 	static char *unit_strings[] = { "bytes", "sectors",
-					"kilobytes", "kibibytes", "megabytes",  "mebibytes",
-					"gigabytes", "gibibytes", "terabytes",  "tebibytes",
-					"petabytes", "pebibytes", "exabytes",   "ebibytes",
-					"zetabytes", "zebibytes", "yottabytes", "yobibytes", NULL };
+					"kibibytes", "kilobytes", "mebibytes", "megabytes",
+					"gibibytes", "gigabytes", "tebibytes", "terabytes",
+					"pebibytes", "petabytes", "ebibytes",  "exabytes",
+					"zebibytes", "zetabytes", "yobibytes", "yottabytes", NULL };
 	static unsigned long long unit_factors[ARRAY_SIZE(unit_strings) - 1] = { 1, 512, 1024, 1000 };
 	struct global *r = malloc(sizeof(*r));
 

--- a/thin-provisioning/thin_metadata_size.rb
+++ b/thin-provisioning/thin_metadata_size.rb
@@ -22,10 +22,10 @@ def init_units
   units[:bytes_per_sector] = 512
   units[:chars] = "bskKmMgGtTpPeEzZyY"
   units[:strings] = [ 'bytes', 'sectors',
-                      'kilobytes', 'kibibytes', 'megabytes',  'mebibytes',
-                      'gigabytes', 'gibibytes', 'terabytes',  'tebibytes',
-                      'petabytes', 'pebibytes', 'exabytes',   'ebibytes',
-                      'zetabytes', 'zebibytes', 'yottabytes', 'yobibytes' ]
+                      'kibibytes', 'kilobytes', 'mebibytes', 'megabytes',
+                      'gibibytes', 'gigabytes', 'tebibytes', 'terabytes',
+                      'pebibytes', 'petabytes', 'ebibytes',  'exabytes',
+                      'zebibytes', 'zetabytes', 'yobibytes', 'yottabytes' ]
   units[:factors] = [ 1, units[:bytes_per_sector] ]
   1.step(8) { |e| units[:factors] += [ 1024**e, 1000**e ] }
   units


### PR DESCRIPTION
Both implementations of `thin_metadata_size` believe units are defined like this:

```
1024 == kilobyte == k
1000 == kibibyte == K
```

and so on.  Fix the 1000/1024 confusion, while continuing to follow the LVM convention of using lowercase letters for binary units, so that we have:

```
1024 == kibibyte == k
1000 == kilobyte == K
```
