### PR TITLE
fix 'may be used uninitialized' warning

### DIFF
--- a/caching/cache_metadata_size.cc
+++ b/caching/cache_metadata_size.cc
@@ -138,6 +138,8 @@ int cache_metadata_size_main(int argc, char **argv)
 {
 	flags fs;
 
+	memset(&fs, 0, sizeof(flags));
+
 	try {
 		switch (parse_command_line(argv[0], argc, argv, fs)) {
 		case FINISH:

--- a/era/era_invalidate.cc
+++ b/era/era_invalidate.cc
@@ -197,6 +197,8 @@ int era_invalidate_main(int argc, char **argv)
 	string output("-");
 	char const shortopts[] = "ho:V";
 
+	memset(&fs, 0, sizeof(flags));
+
 	option const longopts[] = {
 		{ "help", no_argument, NULL, 'h' },
 		{ "output", required_argument, NULL, 'o' },


### PR DESCRIPTION
Probably this is a false positive by some gcc version, but initializing
the memory should be safe.
