### PR TITLE
Fix build errors under musl-libc with strerror_r

### DIFF
--- a/caching/cache_check.cc
+++ b/caching/cache_check.cc
@@ -202,10 +202,16 @@ namespace {
 		int r = ::stat(path.c_str(), &info);
 		if (r) {
 			ostringstream msg;
-			char buffer[128], *ptr;
-
-			ptr = ::strerror_r(errno, buffer, sizeof(buffer));
-			msg << path << ": " << ptr;
+			char buffer[128];
+#ifdef STRERROR_R_CHAR_P /* GNU-specific strerror_r */
+                	char *msg = strerror_r(errno, buffer, sizeof(buffer));
+                	if (msg != buffer)
+                        	strncpy(buffer, msg, sizeof(buffer));
+#else /* POSIX strerror_r variant */
+                	if (strerror_r(errno, buffer, sizeof(buffer)))
+                        	*buffer = '\0';
+#endif
+			msg << path << ": " << buffer;
 			throw runtime_error(msg.str());
 		}
 

--- a/configure.ac
+++ b/configure.ac
@@ -42,6 +42,10 @@ AC_PROG_MAKE_SET
 AC_PROG_MKDIR_P
 AC_PROG_INSTALL
 
+################################################################
+dnl -- Checks for functions.
+AC_FUNC_STRERROR_R
+
 ################################################################################
 dnl -- Prefix is /usr by default, the exec_prefix default is setup later
 AC_PREFIX_DEFAULT(/usr)

--- a/era/era_check.cc
+++ b/era/era_check.cc
@@ -186,10 +186,16 @@ namespace {
 		int r = ::stat(path.c_str(), &info);
 		if (r) {
 			ostringstream msg;
-			char buffer[128], *ptr;
-
-			ptr = ::strerror_r(errno, buffer, sizeof(buffer));
-			msg << path << ": " << ptr;
+			char buffer[128];
+#ifdef STRERROR_R_CHAR_P /* GNU-specific strerror_r */
+                        char *msg = strerror_r(errno, buffer, sizeof(buffer));
+                        if (msg != buffer)
+                                strncpy(buffer, msg, sizeof(buffer));
+#else /* POSIX strerror_r variant */
+                        if (strerror_r(errno, buffer, sizeof(buffer)))
+                                *buffer = '\0';
+#endif
+			msg << path << ": " << buffer;
 			throw runtime_error(msg.str());
 		}
 

--- a/persistent-data/block.tcc
+++ b/persistent-data/block.tcc
@@ -45,10 +45,17 @@ namespace {
 	// to exception.h
 	void syscall_failed(char const *call) {
 		char buffer[128];
-		char *msg = strerror_r(errno, buffer, sizeof(buffer));
 
+#ifdef STRERROR_R_CHAR_P /* GNU-specific strerror_r */
+		char *msg = strerror_r(errno, buffer, sizeof(buffer));
+		if (msg != buffer)
+			strncpy(buffer, msg, sizeof(buffer));
+#else /* POSIX strerror_r variant */
+		if (strerror_r(errno, buffer, sizeof(buffer)))
+			*buffer = '\0';
+#endif
 		ostringstream out;
-		out << "syscall '" << call << "' failed: " << msg;
+		out << "syscall '" << call << "' failed: " << buffer;
 		throw runtime_error(out.str());
 	}
 


### PR DESCRIPTION
* Add conditional to use appropriate implementation of strerror_r
  depending on which version is supported

Need feedback on whether this is the way to go, or if it can be cleaned up. :)