### PR TITLE
Cache check close RO opened device before reopen.

### DIFF
--- a/caching/cache_check.cc
+++ b/caching/cache_check.cc
@@ -220,7 +220,9 @@ namespace {
 		write_superblock(bm, sb);
 	}
 
-	error_state metadata_check(block_manager<>::ptr bm, flags const &fs) {
+	error_state metadata_check(string const &path, flags const &fs) {
+		block_manager<>::ptr bm = open_bm(path, block_manager<>::READ_ONLY);
+
 		nested_output out(cerr, 2);
 		if (fs.quiet_)
 			out.disable();
@@ -295,8 +297,7 @@ namespace {
 			throw runtime_error(msg.str());
 		}
 
-		block_manager<>::ptr bm = open_bm(path, block_manager<>::READ_ONLY);
-		err = metadata_check(bm, fs);
+		err = metadata_check(path, fs);
 
 		bool success = false;
 


### PR DESCRIPTION
When check_check is used with --clear-needs-check-flag option,
device needs to be opened in RW exclusive mode, but for this
existing RO exlusive open must be closed.

LVM2 will consider version 0.5.3 as a version without flag support
for cache_check since it cannot successfully pass cache_check.

TODO: when 'RO' parts detects there is nothing to 'clear' it should
completely skip RW open to avoid udev rule processing.
