### PR TITLE
output allocation bitmap in binary format

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -95,7 +95,8 @@ SOURCE=\
 	thin-provisioning/thin_restore.cc \
 	thin-provisioning/thin_rmap.cc \
 	thin-provisioning/thin_trim.cc \
-	thin-provisioning/xml_format.cc
+	thin-provisioning/xml_format.cc \
+	thin-provisioning/binary_format.cc
 
 CC:=@CC@
 CXX:=@CXX@

--- a/persistent-data/data-structures/btree_damage_visitor.h
+++ b/persistent-data/data-structures/btree_damage_visitor.h
@@ -176,7 +176,6 @@ namespace persistent_data {
 					btree_detail::node_ref<ValueTraits> const &n) {
 				update_path(loc.path);
 
-
 				bool r = check_leaf(loc, n);
 
 				// If anything goes wrong with the checks, we skip

--- a/thin-provisioning/binary_format.cc
+++ b/thin-provisioning/binary_format.cc
@@ -1,0 +1,149 @@
+#include "binary_format.h"
+
+#include <iostream>
+#include <climits>
+
+using namespace std;
+using namespace thin_provisioning;
+
+//----------------------------------------------------------------
+
+namespace {
+	template <typename T>
+	std::ostream &operator << (ostream &out, boost::optional<T> const &maybe) {
+		if (maybe)
+			out << *maybe;
+
+		return out;
+	}
+
+	//------------------------------------------------
+	// binary generator
+	//------------------------------------------------
+	class binary_emitter : public emitter {
+	public:
+		binary_emitter(ostream &out)
+			: out_(out) {
+		}
+
+		void begin_superblock(string const &uuid,
+				      uint64_t time,
+				      uint64_t trans_id,
+				      uint32_t data_block_size,
+				      uint64_t nr_data_blocks,
+				      boost::optional<uint64_t> metadata_snap) {
+		}
+
+		void end_superblock() {
+		}
+
+		void begin_device(uint32_t dev_id,
+				  uint64_t mapped_blocks,
+				  uint64_t trans_id,
+				  uint64_t creation_time,
+				  uint64_t snap_time) {
+			cur = 0;
+			bitmap = 0;
+		}
+
+		void end_device() {
+			emit_bmp();
+		}
+
+		void begin_named_mapping(string const &name) { }
+
+		void end_named_mapping() { }
+
+		void identifier(string const &name) { }
+
+		void range_map(uint64_t origin_begin, uint64_t, uint32_t,
+			uint64_t len) {
+
+			uint64_t n = origin_begin / unit;
+			uint64_t i;
+
+			assert(n >= cur);
+			assert(len > 0);
+
+			/*
+			 * Cover the gap between the last emitted unit and the current one.
+			 */
+			if (n > cur)
+				do { emit_bmp(); } while (cur < n);
+
+			/*
+			 * Emit partial unit.
+			 */
+			if (origin_begin & (unit - 1)) {
+				const uint64_t j = min(len,
+					(origin_begin & ~(unit - 1)) + unit - origin_begin);
+				for (i = origin_begin; i < origin_begin + j; i++)
+					bitmap |= 1ULL << (i & (unit - 1));
+				if (j == len)
+					return;
+
+				emit_bmp();
+
+				len -= j;
+				origin_begin = i;
+			}
+
+			/*
+			 * Emit full units until end.
+			 */
+			n = (origin_begin + len) / unit;
+			while (cur < n) {
+				bitmap = ~0;
+				emit_bmp();
+				len -= unit;
+			}
+			origin_begin = cur * unit;
+
+			/*
+			 * Emit final unit.
+			 */
+			for (i = origin_begin; i < origin_begin + len; i++)
+				bitmap |= 1ULL << (i & (unit - 1));
+		}
+
+		void single_map(uint64_t origin_block, uint64_t, uint32_t) {
+			range_map(origin_block, 0, 0, 1);
+		}
+
+	private:
+		ostream &out_;
+
+		/**
+		 * The entire virtual block allocation bitmap is segmented into 64-bit
+		 * sub-bitmaps (units).
+		 */
+		uint64_t bitmap;
+
+		/*
+		 * Pointer to the current sub-bitmap (unit) that has not yet been
+		 * emitted.
+		 */
+		uint64_t cur;
+
+		/**
+		 * Unit (sub-bitmap) size. Must be a power of 2.
+		 */
+		static const size_t unit = sizeof bitmap * CHAR_BIT;
+
+		void emit_bmp(void) {
+			out_.write((const char*)&bitmap, sizeof bitmap);
+			bitmap = 0;
+			cur++;
+		}
+	};
+}
+
+//----------------------------------------------------------------
+
+thin_provisioning::emitter::ptr
+thin_provisioning::create_binary_emitter(ostream &out)
+{
+	return emitter::ptr(new binary_emitter(out));
+}
+
+//----------------------------------------------------------------

--- a/thin-provisioning/binary_format.cc
+++ b/thin-provisioning/binary_format.cc
@@ -47,7 +47,7 @@ namespace {
 		}
 
 		void end_device() {
-			emit_bmp();
+			emit_bmp(true);
 		}
 
 		void begin_named_mapping(string const &name) { }
@@ -130,8 +130,9 @@ namespace {
 		 */
 		static const size_t unit = sizeof bitmap * CHAR_BIT;
 
-		void emit_bmp(void) {
-			out_.write((const char*)&bitmap, sizeof bitmap);
+		void emit_bmp(bool omit_if_zero = false) {
+			if (!bitmap && omit_if_zero)
+				out_.write((const char*)&bitmap, sizeof bitmap);
 			bitmap = 0;
 			cur++;
 		}

--- a/thin-provisioning/binary_format.h
+++ b/thin-provisioning/binary_format.h
@@ -1,0 +1,16 @@
+#ifndef BINARY_H
+#define BINARY_H
+
+#include "emitter.h"
+
+#include <iosfwd>
+
+//----------------------------------------------------------------
+
+namespace thin_provisioning {
+	emitter::ptr create_binary_emitter(std::ostream &out);
+}
+
+//----------------------------------------------------------------
+
+#endif

--- a/thin-provisioning/metadata_dumper.h
+++ b/thin-provisioning/metadata_dumper.h
@@ -28,7 +28,8 @@ namespace thin_provisioning {
 	// Set the @repair flag if your metadata is corrupt, and you'd like
 	// the dumper to do it's best to recover info.  If not set, any
 	// corruption encountered will cause an exception to be thrown.
-	void metadata_dump(metadata::ptr md, emitter::ptr e, bool repair);
+	void metadata_dump(metadata::ptr md, emitter::ptr e, bool repair,
+		const block_address * const dev_id = NULL);
 }
 
 //----------------------------------------------------------------

--- a/thin-provisioning/xml_format.cc
+++ b/thin-provisioning/xml_format.cc
@@ -17,6 +17,7 @@
 // <http://www.gnu.org/licenses/>.
 
 #include "xml_format.h"
+#include "block-cache/block_cache.h"
 
 #include "base/indented_stream.h"
 #include "base/xml_utils.h"
@@ -32,6 +33,7 @@
 using namespace std;
 using namespace thin_provisioning;
 using namespace xml_utils;
+using namespace bcache;
 
 namespace tp = thin_provisioning;
 
@@ -43,7 +45,7 @@ namespace {
 	//------------------------------------------------
 	class xml_emitter : public emitter {
 	public:
-		xml_emitter(ostream &out)
+		xml_emitter(ostream &out, const block_address * const dev_id = NULL)
 		: out_(out) {
 		}
 


### PR DESCRIPTION
This PR allows thin_dump to output a LV's allocation bitmap in binary format so that it can be easily used by other applications. Since the output must be purely binary, it does not make sense to output the allocation bitmaps, so an option to limit output to a particular LV is added, which is useful in its own right anyway.