### PR TITLE
use -ldl when linking

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -137,7 +137,7 @@ CXXFLAGS+=@CXXDEBUG_FLAG@
 CXXFLAGS+=@CXX_STRERROR_FLAG@
 CXXFLAGS+=@LFS_FLAGS@
 INCLUDES+=-I$(TOP_BUILDDIR) -I$(TOP_DIR) -I$(TOP_DIR)/thin-provisioning
-LIBS:=-laio -lexpat
+LIBS:=-laio -lexpat -ldl
 
 ifeq ("@DEVTOOLS@", "yes")
 LIBS+=-lncurses


### PR DESCRIPTION
```dlopen``` etc. require ```-ldl``` to link

fixes #54