### PR TITLE
Fix unnecessary value visiting in counting_visitor

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -67,6 +67,7 @@ SOURCE=\
 	persistent-data/data-structures/bitset.cc \
 	persistent-data/data-structures/bloom_filter.cc \
 	persistent-data/data-structures/btree.cc \
+	persistent-data/data-structures/btree_node_checker.cc \
 	persistent-data/error_set.cc \
 	persistent-data/file_utils.cc \
 	persistent-data/hex_dump.cc \

--- a/persistent-data/data-structures/btree_counter.h
+++ b/persistent-data/data-structures/btree_counter.h
@@ -2,44 +2,36 @@
 #define PERSISTENT_DATA_DATA_STRUCTURES_BTREE_COUNTER_H
 
 #include "persistent-data/data-structures/btree.h"
-#include "persistent-data/data-structures/btree_base_visitor.h"
-#include "persistent-data/data-structures/btree_damage_visitor.h"
+#include "persistent-data/data-structures/btree_node_checker.h"
 #include "persistent-data/block_counter.h"
 
 //----------------------------------------------------------------
 
 namespace persistent_data {
 	namespace btree_count_detail {
-		template <typename ValueVisitor, typename DamageVisitor, unsigned Levels, typename ValueTraits, typename ValueCounter>
-		class counting_visitor : public btree_damage_visitor<ValueVisitor, DamageVisitor, Levels, ValueTraits> {
-			typedef btree_damage_visitor<ValueVisitor, DamageVisitor, Levels, ValueTraits> BtreeDamageVisitor;
+		template <unsigned Levels, typename ValueTraits, typename ValueCounter>
+		class counting_visitor : public btree<Levels, ValueTraits>::visitor {
 		public:
 			typedef btree<Levels, ValueTraits> tree;
 
-			counting_visitor(ValueVisitor &value_visitor,
-					 DamageVisitor &damage_visitor,
-					 block_counter &bc,
-					 ValueCounter &vc)
-				: BtreeDamageVisitor(value_visitor, damage_visitor, false),
-				  bc_(bc),
+			counting_visitor(block_counter &bc, ValueCounter &vc)
+				: bc_(bc),
 				  vc_(vc) {
 			}
 
 			virtual bool visit_internal(node_location const &l,
 						    typename tree::internal_node const &n) {
-				return BtreeDamageVisitor::visit_internal(l, n) ?
-					visit_node(n) : false;
+				return check_internal(l, n) ? visit_node(n) : false;
 			}
 
 			virtual bool visit_internal_leaf(node_location const &l,
 							 typename tree::internal_node const &n) {
-				return BtreeDamageVisitor::visit_internal_leaf(l, n) ?
-					visit_node(n) : false;
+				return check_leaf(l, n) ? visit_node(n) : false;
 			}
 
 			virtual bool visit_leaf(node_location const &l,
 						typename tree::leaf_node const &n) {
-				if (BtreeDamageVisitor::visit_leaf(l, n) && visit_node(n)) {
+				if (check_leaf(l, n) && visit_node(n)) {
 					unsigned nr = n.get_nr_entries();
 
 					for (unsigned i = 0; i < nr; i++) {
@@ -55,7 +47,57 @@ namespace persistent_data {
 				return false;
 			}
 
+			typedef typename btree<Levels, ValueTraits>::visitor::error_outcome error_outcome;
+
+			error_outcome error_accessing_node(node_location const &l, block_address b,
+							   std::string const &what) {
+				return btree<Levels, ValueTraits>::visitor::EXCEPTION_HANDLED;
+			}
+
 		private:
+			bool check_internal(node_location const &l,
+					    btree_detail::node_ref<block_traits> const &n) {
+				if (!checker_.check_block_nr(n) ||
+				    !checker_.check_value_size(n) ||
+				    !checker_.check_max_entries(n) ||
+				    !checker_.check_nr_entries(n, l.is_sub_root()) ||
+				    !checker_.check_ordered_keys(n) ||
+				    !checker_.check_parent_key(n, l.is_sub_root() ? boost::optional<uint64_t>() : l.key))
+					return false;
+
+				if (l.is_sub_root())
+					new_root(l.level());
+
+				return true;
+			}
+
+			template <typename ValueTraits2>
+			bool check_leaf(node_location const &l,
+				        btree_detail::node_ref<ValueTraits2> const &n) {
+				if (!checker_.check_block_nr(n) ||
+				    !checker_.check_value_size(n) ||
+				    !checker_.check_max_entries(n) ||
+				    !checker_.check_nr_entries(n, l.is_sub_root()) ||
+				    !checker_.check_ordered_keys(n) ||
+				    !checker_.check_parent_key(n, l.is_sub_root() ? boost::optional<uint64_t>() : l.key))
+					return false;
+
+				if (l.is_sub_root())
+					new_root(l.level());
+
+				bool r = checker_.check_leaf_key(n, last_leaf_key_[l.level()]);
+				if (r && n.get_nr_entries() > 0)
+					last_leaf_key_[l.level()] = n.key_at(n.get_nr_entries() - 1);
+
+				return r;
+			}
+
+			void new_root(unsigned level) {
+				// we're starting a new subtree, so should
+				// reset the last_leaf value.
+				last_leaf_key_[level] = boost::optional<uint64_t>();
+			}
+
 			template <typename Node>
 			bool visit_node(Node const &n) {
 				block_address b = n.get_location();
@@ -66,6 +108,8 @@ namespace persistent_data {
 
 			block_counter &bc_;
 			ValueCounter &vc_;
+			btree_node_checker checker_;
+			boost::optional<uint64_t> last_leaf_key_[Levels];
 		};
 	}
 
@@ -94,21 +138,7 @@ namespace persistent_data {
 	// is not corrupt.
 	template <unsigned Levels, typename ValueTraits, typename ValueCounter>
 	void count_btree_blocks(btree<Levels, ValueTraits> const &tree, block_counter &bc, ValueCounter &vc) {
-		typedef noop_value_visitor<typename ValueTraits::value_type> NoopValueVisitor;
-		NoopValueVisitor noop_vv;
-		noop_damage_visitor noop_dv;
-		btree_count_detail::counting_visitor<NoopValueVisitor, noop_damage_visitor, Levels, ValueTraits, ValueCounter> v(noop_vv, noop_dv, bc, vc);
-		tree.visit_depth_first(v);
-	}
-
-	template <unsigned Levels, typename ValueTraits>
-	void count_btree_blocks(btree<Levels, ValueTraits> const &tree, block_counter &bc) {
-		typedef noop_value_visitor<typename ValueTraits::value_type> NoopValueVisitor;
-		NoopValueVisitor noop_vv;
-		noop_damage_visitor noop_dv;
-		typedef noop_value_counter<typename ValueTraits::value_type> NoopValueCounter;
-		NoopValueCounter vc;
-		btree_count_detail::counting_visitor<NoopValueVisitor, noop_damage_visitor, Levels, ValueTraits, NoopValueCounter> v(noop_vv, noop_dv, bc, vc);
+		btree_count_detail::counting_visitor<Levels, ValueTraits, ValueCounter> v(bc, vc);
 		tree.visit_depth_first(v);
 	}
 }

--- a/persistent-data/data-structures/btree_counter.h
+++ b/persistent-data/data-structures/btree_counter.h
@@ -57,6 +57,9 @@ namespace persistent_data {
 		private:
 			bool check_internal(node_location const &l,
 					    btree_detail::node_ref<block_traits> const &n) {
+				if (l.is_sub_root())
+					new_root(l.level());
+
 				if (!checker_.check_block_nr(n) ||
 				    !checker_.check_value_size(n) ||
 				    !checker_.check_max_entries(n) ||
@@ -64,9 +67,6 @@ namespace persistent_data {
 				    !checker_.check_ordered_keys(n) ||
 				    !checker_.check_parent_key(n, l.is_sub_root() ? boost::optional<uint64_t>() : l.key))
 					return false;
-
-				if (l.is_sub_root())
-					new_root(l.level());
 
 				return true;
 			}
@@ -74,22 +74,22 @@ namespace persistent_data {
 			template <typename ValueTraits2>
 			bool check_leaf(node_location const &l,
 				        btree_detail::node_ref<ValueTraits2> const &n) {
+				if (l.is_sub_root())
+					new_root(l.level());
+
 				if (!checker_.check_block_nr(n) ||
 				    !checker_.check_value_size(n) ||
 				    !checker_.check_max_entries(n) ||
 				    !checker_.check_nr_entries(n, l.is_sub_root()) ||
 				    !checker_.check_ordered_keys(n) ||
-				    !checker_.check_parent_key(n, l.is_sub_root() ? boost::optional<uint64_t>() : l.key))
+				    !checker_.check_parent_key(n, l.is_sub_root() ? boost::optional<uint64_t>() : l.key) ||
+				    !checker_.check_leaf_key(n, last_leaf_key_[l.level()]))
 					return false;
 
-				if (l.is_sub_root())
-					new_root(l.level());
-
-				bool r = checker_.check_leaf_key(n, last_leaf_key_[l.level()]);
-				if (r && n.get_nr_entries() > 0)
+				if (n.get_nr_entries() > 0)
 					last_leaf_key_[l.level()] = n.key_at(n.get_nr_entries() - 1);
 
-				return r;
+				return true;
 			}
 
 			void new_root(unsigned level) {

--- a/persistent-data/data-structures/btree_damage_visitor.h
+++ b/persistent-data/data-structures/btree_damage_visitor.h
@@ -158,9 +158,8 @@ namespace persistent_data {
 			typedef boost::optional<run64> maybe_run64;
 
 			btree_damage_visitor(ValueVisitor &value_visitor,
-					     DamageVisitor &damage_visitor,
-					     bool avoid_repeated_visits = true)
-				: avoid_repeated_visits_(avoid_repeated_visits),
+					     DamageVisitor &damage_visitor)
+				: avoid_repeated_visits_(true),
 				  value_visitor_(value_visitor),
 				  damage_visitor_(damage_visitor) {
 			}

--- a/persistent-data/data-structures/btree_node_checker.cc
+++ b/persistent-data/data-structures/btree_node_checker.cc
@@ -1,0 +1,127 @@
+#include "btree_node_checker.h"
+
+#include <sstream>
+
+using persistent_data::btree_detail::btree_node_checker;
+
+//----------------------------------------------------------------
+
+btree_node_checker::error_type btree_node_checker::get_last_error() {
+	return last_error_;
+}
+
+std::string btree_node_checker::get_last_error_string() {
+	switch (last_error_) {
+	case BLOCK_NR_MISMATCH:
+		return block_nr_mismatch_string();
+	case VALUE_SIZES_MISMATCH:
+		return value_sizes_mismatch_string();
+	case MAX_ENTRIES_TOO_LARGE:
+		return max_entries_too_large_string();
+	case MAX_ENTRIES_NOT_DIVISIBLE:
+		return max_entries_not_divisible_string();
+	case NR_ENTRIES_TOO_LARGE:
+		return nr_entries_too_large_string();
+	case NR_ENTRIES_TOO_SMALL:
+		return nr_entries_too_small_string();
+	case KEYS_OUT_OF_ORDER:
+		return keys_out_of_order_string();
+	case PARENT_KEY_MISMATCH:
+		return parent_key_mismatch_string();
+	case LEAF_KEY_OVERLAPPED:
+		return leaf_key_overlapped_string();
+	default:
+		return std::string();
+	}
+}
+
+void btree_node_checker::reset() {
+	last_error_ = NO_ERROR;
+}
+
+std::string btree_node_checker::block_nr_mismatch_string() {
+	std::ostringstream out;
+	out << "block number mismatch: actually "
+	    << error_location_
+	    << ", claims " << error_block_nr_;
+
+	return out.str();
+}
+
+std::string btree_node_checker::value_sizes_mismatch_string() {
+	std::ostringstream out;
+	out << "value size mismatch: expected " << error_value_sizes_[1]
+	    << ", but got " << error_value_sizes_[0]
+	    << ". This is not the btree you are looking for."
+	    << " (block " << error_location_ << ")";
+
+	return out.str();
+}
+
+std::string btree_node_checker::max_entries_too_large_string() {
+	std::ostringstream out;
+	out << "max entries too large: " << error_max_entries_
+	    << " (block " << error_location_ << ")";
+
+	return out.str();
+}
+
+std::string btree_node_checker::max_entries_not_divisible_string() {
+	std::ostringstream out;
+	out << "max entries is not divisible by 3: " << error_max_entries_
+	    << " (block " << error_location_ << ")";
+
+	return out.str();
+}
+
+std::string btree_node_checker::nr_entries_too_large_string() {
+	std::ostringstream out;
+	out << "bad nr_entries: "
+	    << error_nr_entries_ << " < "
+	    << error_max_entries_
+	    << " (block " << error_location_ << ")";
+
+	return out.str();
+}
+
+std::string btree_node_checker::nr_entries_too_small_string() {
+	std::ostringstream out;
+	out << "too few entries in btree_node: "
+	    << error_nr_entries_
+	    << ", expected at least "
+	    << (error_max_entries_ / 3)
+	    << " (block " << error_location_
+	    << ", max_entries = " << error_max_entries_ << ")";
+
+	return out.str();
+}
+
+std::string btree_node_checker::keys_out_of_order_string() {
+	std::ostringstream out;
+	out << "keys are out of order, "
+	    << error_keys_[0] << " <= " << error_keys_[1]
+	    << " (block " << error_location_ << ")";
+
+	return out.str();
+}
+
+std::string btree_node_checker::parent_key_mismatch_string() {
+	std::ostringstream out;
+	out << "parent key mismatch: parent was " << error_keys_[1]
+	    << ", but lowest in node was " << error_keys_[0]
+	    << " (block " << error_location_ << ")";
+
+	return out.str();
+}
+
+std::string btree_node_checker::leaf_key_overlapped_string() {
+	std::ostringstream out;
+	out << "the last key of the previous leaf was " << error_keys_[1]
+	    << " and the first key of this leaf is " << error_keys_[0]
+	    << " (block " << error_location_ << ")";
+
+	return out.str();
+}
+
+//----------------------------------------------------------------
+

--- a/persistent-data/data-structures/btree_node_checker.h
+++ b/persistent-data/data-structures/btree_node_checker.h
@@ -1,0 +1,206 @@
+#ifndef BTREE_NODE_CHECKER_H
+#define BTREE_NODE_CHECKER_H
+
+#include "block-cache/block_cache.h"
+#include "persistent-data/block.h"
+#include "persistent-data/data-structures/btree.h"
+#include "persistent-data/data-structures/btree_disk_structures.h"
+
+#include <boost/optional.hpp>
+#include <string>
+
+using bcache::block_address;
+
+//----------------------------------------------------------------
+
+namespace persistent_data {
+	namespace btree_detail {
+		class btree_node_checker {
+		public:
+			enum error_type {
+				NO_ERROR,
+				BLOCK_NR_MISMATCH,
+				VALUE_SIZES_MISMATCH,
+				MAX_ENTRIES_TOO_LARGE,
+				MAX_ENTRIES_NOT_DIVISIBLE,
+				NR_ENTRIES_TOO_LARGE,
+				NR_ENTRIES_TOO_SMALL,
+				KEYS_OUT_OF_ORDER,
+				VALUE_SIZE_MISMATCH,
+				PARENT_KEY_MISMATCH,
+				LEAF_KEY_OVERLAPPED,
+			};
+
+			btree_node_checker():
+				last_error_(NO_ERROR),
+				error_location_(0),
+				error_block_nr_(0),
+				error_nr_entries_(0),
+				error_max_entries_(0),
+				error_value_sizes_{0, 0},
+				error_keys_{0, 0} {
+			}
+
+			template <typename ValueTraits>
+			bool check_block_nr(btree_detail::node_ref<ValueTraits> const &n) {
+				if (n.get_location() != n.get_block_nr()) {
+					last_error_ = BLOCK_NR_MISMATCH;
+					error_block_nr_ = n.get_block_nr();
+					error_location_ = n.get_location();
+
+					return false;
+				}
+
+				return true;
+			}
+
+			template <typename ValueTraits>
+			bool check_value_size(btree_detail::node_ref<ValueTraits> const &n) {
+				if (!n.value_sizes_match()) {
+					last_error_ = VALUE_SIZES_MISMATCH;
+					error_location_ = n.get_location();
+					error_value_sizes_[0] = n.get_value_size();
+					error_value_sizes_[1] = sizeof(typename ValueTraits::disk_type);
+					return false;
+				}
+
+				return true;
+			}
+
+			template <typename ValueTraits>
+			bool check_max_entries(btree_detail::node_ref<ValueTraits> const &n) {
+				size_t elt_size = sizeof(uint64_t) + n.get_value_size();
+				if (elt_size * n.get_max_entries() + sizeof(node_header) > MD_BLOCK_SIZE) {
+					last_error_ = MAX_ENTRIES_TOO_LARGE;
+					error_location_ = n.get_location();
+					error_max_entries_ = n.get_max_entries();
+
+					return false;
+				}
+
+				if (n.get_max_entries() % 3) {
+					last_error_ = MAX_ENTRIES_NOT_DIVISIBLE;
+					error_location_ = n.get_location();
+					error_max_entries_ = n.get_max_entries();
+
+					return false;
+				}
+
+				return true;
+			}
+
+			template <typename ValueTraits>
+			bool check_nr_entries(btree_detail::node_ref<ValueTraits> const &n,
+					      bool is_root) {
+				if (n.get_nr_entries() > n.get_max_entries()) {
+					last_error_ = NR_ENTRIES_TOO_LARGE;
+					error_location_ = n.get_location();
+					error_nr_entries_ = n.get_nr_entries();
+					error_max_entries_ = n.get_max_entries();
+
+					return false;
+				}
+
+				block_address min = n.get_max_entries() / 3;
+				if (!is_root && (n.get_nr_entries() < min)) {
+					last_error_ = NR_ENTRIES_TOO_SMALL;
+					error_location_ = n.get_location();
+					error_nr_entries_ = n.get_nr_entries();
+					error_max_entries_ = n.get_max_entries();
+
+					return false;
+				}
+
+				return true;
+			}
+
+			template <typename ValueTraits>
+			bool check_ordered_keys(btree_detail::node_ref<ValueTraits> const &n) {
+				unsigned nr_entries = n.get_nr_entries();
+
+				if (nr_entries == 0)
+					return true; // can only happen if a root node
+
+				uint64_t last_key = n.key_at(0);
+
+				for (unsigned i = 1; i < nr_entries; i++) {
+					uint64_t k = n.key_at(i);
+					if (k <= last_key) {
+						last_error_ = KEYS_OUT_OF_ORDER;
+						error_location_ = n.get_location();
+						error_keys_[0] = k;
+						error_keys_[1] = last_key;
+
+						return false;
+					}
+					last_key = k;
+				}
+
+				return true;
+			}
+
+			template <typename ValueTraits>
+			bool check_parent_key(btree_detail::node_ref<ValueTraits> const &n,
+					      boost::optional<uint64_t> key) {
+				if (!key)
+					return true;
+
+				if (*key > n.key_at(0)) {
+					last_error_ = PARENT_KEY_MISMATCH;
+					error_location_ = n.get_location();
+					error_keys_[0] = n.key_at(0);
+					error_keys_[1] = *key;
+
+					return false;
+				}
+
+				return true;
+			}
+
+			template <typename ValueTraits>
+			bool check_leaf_key(btree_detail::node_ref<ValueTraits> const &n,
+					    boost::optional<uint64_t> key) {
+				if (n.get_nr_entries() == 0)
+					return true; // can only happen if a root node
+
+				if (key && *key >= n.key_at(0)) {
+					last_error_ = LEAF_KEY_OVERLAPPED;
+					error_location_ = n.get_location();
+					error_keys_[0] = n.key_at(0);
+					error_keys_[1] = *key;
+
+					return false;
+				}
+
+				return true;
+			}
+
+			error_type get_last_error();
+			std::string get_last_error_string();
+			void reset();
+
+		private:
+			std::string block_nr_mismatch_string();
+			std::string value_sizes_mismatch_string();
+			std::string max_entries_too_large_string();
+			std::string max_entries_not_divisible_string();
+			std::string nr_entries_too_large_string();
+			std::string nr_entries_too_small_string();
+			std::string keys_out_of_order_string();
+			std::string parent_key_mismatch_string();
+			std::string leaf_key_overlapped_string();
+
+			error_type last_error_;
+			block_address error_location_;
+			block_address error_block_nr_;
+			uint32_t error_nr_entries_;
+			uint32_t error_max_entries_;
+			uint32_t error_value_sizes_[2];
+			uint64_t error_keys_[2];
+		};
+	}
+}
+
+//----------------------------------------------------------------
+
+#endif

--- a/thin-provisioning/metadata_counter.cc
+++ b/thin-provisioning/metadata_counter.cc
@@ -66,7 +66,6 @@ void thin_provisioning::count_metadata(transaction_manager::ptr tm,
 		count_trees(tm, snap, bc);
 	}
 
-	count_trees(tm, sb, bc);
 	count_space_maps(tm, sb, bc);
 }
 

--- a/thin-provisioning/thin_check.cc
+++ b/thin-provisioning/thin_check.cc
@@ -31,6 +31,7 @@
 #include "persistent-data/file_utils.h"
 #include "thin-provisioning/device_tree.h"
 #include "thin-provisioning/mapping_tree.h"
+#include "thin-provisioning/metadata_counter.h"
 #include "thin-provisioning/superblock.h"
 #include "thin-provisioning/commands.h"
 
@@ -169,58 +170,13 @@ namespace {
 		bool clear_needs_check_flag_on_success;
 	};
 
-	void count_trees(transaction_manager::ptr tm,
-			 superblock_detail::superblock &sb,
-			 block_counter &bc) {
-
-		// Count the device tree
-		{
-			noop_value_counter<device_tree_detail::device_details> vc;
-			device_tree dtree(*tm, sb.device_details_root_,
-					  device_tree_detail::device_details_traits::ref_counter());
-			count_btree_blocks(dtree, bc, vc);
-		}
-
-		// Count the mapping tree
-		{
-			noop_value_counter<mapping_tree_detail::block_time> vc;
-			mapping_tree mtree(*tm, sb.data_mapping_root_,
-					   mapping_tree_detail::block_traits::ref_counter(tm->get_sm()));
-			count_btree_blocks(mtree, bc, vc);
-		}
-	}
-
 	error_state check_space_map_counts(flags const &fs, nested_output &out,
 					   superblock_detail::superblock &sb,
 					   block_manager<>::ptr bm,
 					   transaction_manager::ptr tm) {
 		block_counter bc;
 
-		// Count the superblock
-		bc.inc(superblock_detail::SUPERBLOCK_LOCATION);
-		count_trees(tm, sb, bc);
-
-		// Count the metadata snap, if present
-		if (sb.metadata_snap_ != superblock_detail::SUPERBLOCK_LOCATION) {
-			bc.inc(sb.metadata_snap_);
-
-			superblock_detail::superblock snap = read_superblock(bm, sb.metadata_snap_);
-			count_trees(tm, snap, bc);
-		}
-
-		// Count the metadata space map
-		{
-			persistent_space_map::ptr metadata_sm =
-				open_metadata_sm(*tm, static_cast<void *>(&sb.metadata_space_map_root_));
-			metadata_sm->count_metadata(bc);
-		}
-
-		// Count the data space map
-		{
-			persistent_space_map::ptr data_sm =
-				open_disk_sm(*tm, static_cast<void *>(&sb.data_space_map_root_));
-			data_sm->count_metadata(bc);
-		}
+		count_metadata(tm, sb, bc);
 
 		// Finally we need to check the metadata space map agrees
 		// with the counts we've just calculated.


### PR DESCRIPTION
As mentioned in the comment of b2249599, I don't want counting_visitor to inherit btree_damage_visitor
https://github.com/jthornber/thin-provisioning-tools/commit/b22495997a8bf427741225ef86edf267ee746d7c

So I extracted the node checking functions into a stand-alone class btree_node_checker, and use it in btree_damage_visitor, counting_visitor, and thin_ll_dump.

Notes:

1. I don't want node_ref become a heavy-weight class, so the node checking functions are not members of node_ref. (unlike node_ref::value_sizes_match())
2. Error strings are returned by private members of btree_node_checker, because they only have meaning when error happened. (unlike that node_ref::value_mismatch_string() is public)
3. In the last two commits, I moved the new_root() call to the beginning of check_internal() and check_leaf().
