### PR TITLE
fix up test targets

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -229,12 +229,13 @@ install: bin/pdata_tools
 ifeq ("@TESTING@", "yes")
 include unit-tests/Makefile
 
-.PHONEY: features
+.PHONY: features test check
 
-features: pdata_tools
+features: bin/pdata_tools
 	cucumber --no-color --format progress
 
 test: features unit-test
+check: unit-test
 endif
 
 -include $(DEPEND_FILES)

--- a/unit-tests/Makefile.in
+++ b/unit-tests/Makefile.in
@@ -84,7 +84,7 @@ unit-tests/unit_tests: $(TEST_OBJECTS) lib/libgmock.a lib/libpdata.a
 	@echo "    [LD]  $<"
 	$(V)g++ $(CXXFLAGS) $(LDFLAGS) -o $@ $(TEST_OBJECTS) $(LIBS) $(GMOCK_LIBS) $(LIBEXPAT)
 
-.PHONEY: unit-test
+.PHONY: unit-test
 
 unit-test: unit-tests/unit_tests
 	unit-tests/unit_tests


### PR DESCRIPTION
- PHONY is misspelled
- fix the pdata_tools target dep
- add a "check" alias to match standard automake behavior
- mark test & check targets as phony