### PR TITLE
Minor fixes for new dev-tools

### DIFF
--- a/base/output_file_requirements.cc
+++ b/base/output_file_requirements.cc
@@ -37,14 +37,17 @@ base::check_output_file_requirements(string const &path)
 		explain_output_file_requirements();
 	}
 
-	if (!info.st_size) {
-		cerr << "Zero size output file.\n\n";
-		explain_output_file_requirements();
-	}
+	// We only really want these checks for regular files
+	if (S_ISREG(info.st_mode)) {
+		if (!info.st_size) {
+			cerr << "Zero size output file.\n\n";
+			explain_output_file_requirements();
+		}
 
-	if (info.st_size < MIN_SIZE) {
-		cerr << "Output file too small.\n\n";
-		explain_output_file_requirements();
+		if (info.st_size < MIN_SIZE) {
+			cerr << "Output file too small.\n\n";
+			explain_output_file_requirements();
+		}
 	}
 }
 

--- a/persistent-data/data-structures/btree.h
+++ b/persistent-data/data-structures/btree.h
@@ -322,7 +322,7 @@ namespace persistent_data {
 		maybe_pair lookup_le(key const &key) const;
 		maybe_pair lookup_ge(key const &key) const;
 
-		void insert(key const &key, typename ValueTraits::value_type const &value);
+		bool insert(key const &key, typename ValueTraits::value_type const &value);
 		void remove(key const &key);
 
 		void set_root(block_address root);

--- a/persistent-data/data-structures/btree.tcc
+++ b/persistent-data/data-structures/btree.tcc
@@ -498,7 +498,7 @@ namespace persistent_data {
 	}
 
 	template <unsigned Levels, typename ValueTraits>
-	void
+	bool
 	btree<Levels, ValueTraits>::
 	insert(key const &key,
 	       typename ValueTraits::value_type const &value)
@@ -531,6 +531,8 @@ namespace persistent_data {
 			n.set_value(index, value);
 
 		root_ = spine.get_root();
+
+		return need_insert;
 	}
 
 	template <unsigned Levels, typename ValueTraits>

--- a/thin-provisioning/restore_emitter.cc
+++ b/thin-provisioning/restore_emitter.cc
@@ -136,10 +136,9 @@ namespace {
 			mapping_tree_detail::block_time bt;
 			bt.block_ = data_block;
 			bt.time_ = time;
-			current_mapping_->insert(key, bt);
+			current_device_details_.mapped_blocks_ +=
+				static_cast<uint64_t>(current_mapping_->insert(key, bt));
 			md_->data_sm_->inc(data_block);
-
-			current_device_details_.mapped_blocks_ += 1;
 		}
 
 	private:

--- a/thin-provisioning/thin_ll_restore.cc
+++ b/thin-provisioning/thin_ll_restore.cc
@@ -14,6 +14,7 @@
 // with thin-provisioning-tools.  If not, see
 // <http://www.gnu.org/licenses/>.
 
+#include "base/output_file_requirements.h"
 #include "base/xml_utils.h"
 #include "metadata_dumper.h"
 #include "metadata.h"
@@ -261,11 +262,24 @@ thin_ll_restore_cmd::run(int argc, char **argv) {
 		return 1;
 	}
 
-	if (!input_metadata.length() || !input.length() || !output.length()) {
-		cerr << "No input/output file provided." << endl;
+	if (!input.length()) {
+		cerr << "No input file provided." << endl;
 		usage(cerr);
 		return 1;
 	}
+
+	if (!input_metadata.length()) {
+		cerr << "No input metadata provided." << endl;
+		usage(cerr);
+		return 1;
+	}
+
+	if (!output.length()) {
+		cerr << "No output file provided." << endl;
+		usage(cerr);
+		return 1;
+	} else
+		check_output_file_requirements(output);
 
 	return low_level_restore(input_metadata, input, output, f);
 }

--- a/thin-provisioning/thin_pool.cc
+++ b/thin-provisioning/thin_pool.cc
@@ -50,7 +50,7 @@ thin::lookup(block_address thin_block)
 	return pool_->md_->mappings_->lookup(key);
 }
 
-void
+bool
 thin::insert(block_address thin_block, block_address data_block)
 {
 	uint64_t key[2] = {dev_, thin_block};

--- a/thin-provisioning/thin_pool.h
+++ b/thin-provisioning/thin_pool.h
@@ -39,7 +39,7 @@ namespace thin_provisioning {
 
 		thin_dev_t get_dev_t() const;
 		maybe_address lookup(block_address thin_block);
-		void insert(block_address thin_block, block_address data_block);
+		bool insert(block_address thin_block, block_address data_block);
 		void remove(block_address thin_block);
 
 		void set_snapshot_time(uint32_t time);


### PR DESCRIPTION
1. thin_ll_restore allows the input subtrees to have duplicated keys, and the mapped values will be replaced by the later ones (see btree::insert() ). To avoid recounting the duplicated keys in restore emitter, I changed the return value of btree::insert() to bool to know whether the key was inserted or not.

2. Cherry-pick 44351860 from master, then adopt check_output_file_requirements() in thin_ll_restore.