### PR TITLE
fix compilation for gcc 5.4.0

### DIFF
--- a/caching/cache_writeback.cc
+++ b/caching/cache_writeback.cc
@@ -10,6 +10,7 @@
 #include <getopt.h>
 #include <string>
 #include <stdexcept>
+#include <boost/optional/optional_io.hpp>
 
 using namespace bcache;
 using namespace caching;

--- a/contrib/Makefile.in
+++ b/contrib/Makefile.in
@@ -12,7 +12,7 @@ contrib: $(PLUGINS) $(PLUGIN_LIBS)
 
 contrib/%.o: contrib/%.cc
 	$(V)echo "    [CC] $@"
-	$(V)$(CC) $^ -o $@
+	$(V)$(CXX) $(INCLUDES) $(CXXFLAGS) $^ -c -o $@
 
 contrib/%.a: contrib/%.o
 	$(V)echo "    [AR] $@"

--- a/thin-provisioning/static_library_emitter.cc
+++ b/thin-provisioning/static_library_emitter.cc
@@ -1,6 +1,7 @@
 #include "thin-provisioning/shared_library_emitter.h"
 #include <stdexcept>
 #include "contrib/tmakatos_emitter.h"
+#include <iostream>
 
 using namespace std;
 using namespace thin_provisioning;


### PR DESCRIPTION
Building thin-provisioning tools on Ubuntu 16.04 (make 4.1, gcc 5.4.0) fails, this patch addresses the build failures.