### PR TITLE
[block-cache] Fix error handling in reading libaio events

### DIFF
--- a/block-cache/block_cache.cc
+++ b/block-cache/block_cache.cc
@@ -213,7 +213,7 @@ block_cache::wait_io()
 		if (e.res == block_size_ << SECTOR_SHIFT)
 			complete_io(*b, 0);
 
-		else if (e.res < 0)
+		else if (static_cast<long>(e.res) < 0)
 			complete_io(*b, e.res);
 
 		else {


### PR DESCRIPTION
io_event::res is a signed int64 in kernel, but libaio defines it
as unsigned long. We should cast it to a signed value.
(Finally I cast it to <long> for safety)