### PR TITLE
Spin-off syscall-related file operations

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -33,6 +33,7 @@ SOURCE=\
 	base/error_state.cc \
 	base/error_string.cc \
 	base/grid_layout.cc \
+	base/file_utils.cc \
 	base/progress_monitor.cc \
 	base/rolling_hash.cc \
 	base/xml_utils.cc \

--- a/base/file_utils.cc
+++ b/base/file_utils.cc
@@ -1,0 +1,120 @@
+#include "base/file_utils.h"
+
+#include "base/error_string.h"
+
+#include <sstream>
+#include <stdexcept>
+#include <sys/stat.h>
+#include <fcntl.h>
+#include <unistd.h>
+
+//----------------------------------------------------------------
+
+// FIXME: give this namespace a name
+namespace {
+	using namespace std;
+
+	int const DEFAULT_MODE = 0666;
+	int const OPEN_FLAGS = O_DIRECT;
+
+	// FIXME: introduce a new exception for this, or at least lift this
+	// to exception.h
+	void syscall_failed(char const *call) {
+		ostringstream out;
+		out << "syscall '" << call << "' failed: " << base::error_string(errno);
+		throw runtime_error(out.str());
+	}
+
+	void syscall_failed(string const &call, string const &message)
+	{
+		ostringstream out;
+		out << "syscall '" << call << "' failed: " << base::error_string(errno) << "\n"
+		    << message;
+		throw runtime_error(out.str());
+	}
+}
+
+//----------------------------------------------------------------
+
+int
+file_utils::open_file(string const &path, int flags) {
+	int fd = ::open(path.c_str(), OPEN_FLAGS | flags, DEFAULT_MODE);
+	if (fd < 0)
+		syscall_failed("open",
+			       "Note: you cannot run this tool with these options on live metadata.");
+
+	return fd;
+}
+
+bool
+file_utils::file_exists(string const &path) {
+	struct ::stat info;
+
+	int r = ::stat(path.c_str(), &info);
+	if (r) {
+		if (errno == ENOENT)
+			return false;
+
+		syscall_failed("stat");
+		return false; // never get here
+
+	} else
+		return S_ISREG(info.st_mode) || S_ISBLK(info.st_mode);
+}
+
+void
+file_utils::check_file_exists(string const &file) {
+	struct stat info;
+	int r = ::stat(file.c_str(), &info);
+	if (r)
+		throw runtime_error("Couldn't stat file");
+
+	if (!S_ISREG(info.st_mode))
+		throw runtime_error("Not a regular file");
+}
+
+int
+file_utils::create_block_file(string const &path, off_t file_size) {
+	if (file_exists(path)) {
+		ostringstream out;
+		out << __FUNCTION__ << ": file '" << path << "' already exists";
+		throw runtime_error(out.str());
+	}
+
+	int fd = open_file(path, O_CREAT | O_EXCL | O_RDWR);
+
+	int r = ::ftruncate(fd, file_size);
+	if (r < 0)
+		syscall_failed("ftruncate");
+
+	return fd;
+}
+
+int
+file_utils::open_block_file(string const &path, off_t min_size, bool writeable, bool excl) {
+	if (!file_exists(path)) {
+		ostringstream out;
+		out << __FUNCTION__ << ": file '" << path << "' doesn't exist";
+		throw runtime_error(out.str());
+	}
+
+	int flags = writeable ? O_RDWR : O_RDONLY;
+	if (excl)
+		flags |= O_EXCL;
+
+	return open_file(path, flags);
+}
+
+size_t
+file_utils::get_file_length(string const &file) {
+	struct stat info;
+	int r;
+
+	r = ::stat(file.c_str(), &info);
+	if (r)
+		throw runtime_error("Couldn't stat path");
+
+	return info.st_size;
+}
+
+//----------------------------------------------------------------

--- a/base/file_utils.h
+++ b/base/file_utils.h
@@ -1,0 +1,20 @@
+#ifndef BASE_FILE_UTILS_H
+#define BASE_FILE_UTILS_H
+
+#include <string>
+#include <sys/types.h>
+
+//----------------------------------------------------------------
+
+namespace file_utils {
+	int open_file(std::string const &path, int flags);
+	bool file_exists(std::string const &path);
+	void check_file_exists(std::string const &file);
+	int create_block_file(std::string const &path, off_t file_size);
+	int open_block_file(std::string const &path, off_t min_size, bool writeable, bool excl = true);
+	size_t get_file_length(std::string const &file);
+}
+
+//----------------------------------------------------------------
+
+#endif

--- a/base/file_utils.h
+++ b/base/file_utils.h
@@ -3,6 +3,7 @@
 
 #include <string>
 #include <sys/types.h>
+#include <stdint.h>
 
 //----------------------------------------------------------------
 
@@ -12,7 +13,7 @@ namespace file_utils {
 	void check_file_exists(std::string const &file);
 	int create_block_file(std::string const &path, off_t file_size);
 	int open_block_file(std::string const &path, off_t min_size, bool writeable, bool excl = true);
-	size_t get_file_length(std::string const &file);
+	uint64_t get_file_length(std::string const &file);
 }
 
 //----------------------------------------------------------------

--- a/base/xml_utils.cc
+++ b/base/xml_utils.cc
@@ -1,8 +1,9 @@
 #include "xml_utils.h"
 
-#include "persistent-data/file_utils.h"
+#include "base/file_utils.h"
 #include <fstream>
 #include <iostream>
+#include <sys/stat.h>
 
 using namespace xml_utils;
 
@@ -11,13 +12,13 @@ using namespace xml_utils;
 void
 xml_parser::parse(std::string const &backup_file, bool quiet)
 {
-	persistent_data::check_file_exists(backup_file);
+	file_utils::check_file_exists(backup_file);
 	ifstream in(backup_file.c_str(), ifstream::in);
 
 	std::unique_ptr<base::progress_monitor> monitor = create_monitor(quiet);
 
 	size_t total = 0;
-	size_t input_length = get_file_length(backup_file);
+	size_t input_length = file_utils::get_file_length(backup_file);
 
 	XML_Error error_code = XML_ERROR_NONE;
 	while (!in.eof() && error_code == XML_ERROR_NONE) {
@@ -41,19 +42,6 @@ xml_parser::parse(std::string const &backup_file, bool quiet)
 		total += len;
 		monitor->update_percent(total * 100 / input_length);
 	}
-}
-
-size_t
-xml_parser::get_file_length(string const &file) const
-{
-	struct stat info;
-	int r;
-
-	r = ::stat(file.c_str(), &info);
-	if (r)
-		throw runtime_error("Couldn't stat backup path");
-
-	return info.st_size;
 }
 
 unique_ptr<base::progress_monitor>

--- a/base/xml_utils.h
+++ b/base/xml_utils.h
@@ -36,7 +36,6 @@ namespace xml_utils {
 		void parse(std::string const &backup_file, bool quiet);
 
 	private:
-		size_t get_file_length(string const &file) const;
 		unique_ptr<base::progress_monitor> create_monitor(bool quiet);
 
 		XML_Parser parser_;

--- a/caching/cache_restore.cc
+++ b/caching/cache_restore.cc
@@ -1,5 +1,6 @@
 #include "version.h"
 
+#include "base/file_utils.h"
 #include "base/output_file_requirements.h"
 #include "caching/commands.h"
 #include "caching/metadata.h"
@@ -17,22 +18,12 @@
 using namespace boost;
 using namespace caching;
 using namespace persistent_data;
+using namespace file_utils;
 using namespace std;
 
 //----------------------------------------------------------------
 
 namespace {
-	size_t get_file_length(string const &file) {
-		struct stat info;
-		int r;
-
-		r = ::stat(file.c_str(), &info);
-		if (r)
-			throw runtime_error("Couldn't stat backup path");
-
-		return info.st_size;
-	}
-
 	unique_ptr<progress_monitor> create_monitor(bool quiet) {
 		if (!quiet && isatty(fileno(stdout)))
 			return create_progress_bar("Restoring");

--- a/era/superblock.cc
+++ b/era/superblock.cc
@@ -3,10 +3,13 @@
 #include "persistent-data/checksum.h"
 #include "persistent-data/errors.h"
 
+#include <sstream>
+
 using namespace base;
 using namespace era;
 using namespace superblock_damage;
 using namespace persistent_data;
+using namespace std;
 
 //----------------------------------------------------------------
 

--- a/persistent-data/block_counter.h
+++ b/persistent-data/block_counter.h
@@ -38,7 +38,7 @@ namespace persistent_data {
 		virtual void inc(block_address b) {
 			count_map::iterator it = counts_.find(b);
 			if (it == counts_.end())
-				counts_.insert(make_pair(b, 1));
+				counts_.insert(std::make_pair(b, 1));
 			else
 				it->second++;
 		}

--- a/persistent-data/data-structures/bloom_filter.cc
+++ b/persistent-data/data-structures/bloom_filter.cc
@@ -3,6 +3,7 @@
 #include <stdexcept>
 
 using namespace persistent_data;
+using namespace std;
 
 //----------------------------------------------------------------
 
@@ -91,7 +92,7 @@ bloom_filter::flush()
 }
 
 void
-bloom_filter::fill_probes(block_address b, vector<unsigned> &probes) const
+bloom_filter::fill_probes(block_address b, std::vector<unsigned> &probes) const
 {
 	uint32_t h1 = hash1(b) & mask_;
 	uint32_t h2 = hash2(b) & mask_;
@@ -105,7 +106,7 @@ bloom_filter::fill_probes(block_address b, vector<unsigned> &probes) const
 }
 
 void
-bloom_filter::print_debug(ostream &out)
+bloom_filter::print_debug(std::ostream &out)
 {
 	print_residency(out);
 
@@ -133,7 +134,7 @@ bloom_filter::print_debug(ostream &out)
 }
 
 void
-bloom_filter::print_residency(ostream &out)
+bloom_filter::print_residency(std::ostream &out)
 {
 	unsigned count = 0;
 	for (unsigned i = 0; i < bits_.get_nr_bits(); i++)

--- a/persistent-data/data-structures/bloom_filter.h
+++ b/persistent-data/data-structures/bloom_filter.h
@@ -26,12 +26,12 @@ namespace persistent_data {
 		void set(uint64_t b);
 		void flush();
 
-		void print_debug(ostream &out);
+		void print_debug(std::ostream &out);
 
 	private:
-		void print_residency(ostream &out);
+		void print_residency(std::ostream &out);
 
-		void fill_probes(block_address b, vector<unsigned> &probes) const;
+		void fill_probes(block_address b, std::vector<unsigned> &probes) const;
 
 		transaction_manager &tm_;
 		persistent_data::bitset bits_;

--- a/persistent-data/data-structures/btree.tcc
+++ b/persistent-data/data-structures/btree.tcc
@@ -24,6 +24,7 @@
 #include "persistent-data/validators.h"
 
 #include <iostream>
+#include <sstream>
 
 //----------------------------------------------------------------
 

--- a/persistent-data/file_utils.cc
+++ b/persistent-data/file_utils.cc
@@ -5,16 +5,19 @@
 #include <sys/ioctl.h>
 #include <sys/types.h>
 #include <sys/stat.h>
+#include <fcntl.h>
+#include <sstream>
 #include <unistd.h>
 
 using namespace base;
 using namespace bcache;
 using namespace persistent_data;
+using namespace std;
 
 //----------------------------------------------------------------
 
 persistent_data::block_address
-persistent_data::get_nr_blocks(string const &path, sector_t block_size)
+persistent_data::get_nr_blocks(std::string const &path, sector_t block_size)
 {
 	using namespace persistent_data;
 
@@ -54,7 +57,7 @@ persistent_data::get_nr_blocks(string const &path, sector_t block_size)
 }
 
 block_address
-persistent_data::get_nr_metadata_blocks(string const &path)
+persistent_data::get_nr_metadata_blocks(std::string const &path)
 {
 	return get_nr_blocks(path, MD_BLOCK_SIZE);
 }
@@ -64,17 +67,6 @@ persistent_data::open_bm(std::string const &dev_path, block_manager<>::mode m, b
 {
 	block_address nr_blocks = get_nr_metadata_blocks(dev_path);
 	return block_manager<>::ptr(new block_manager<>(dev_path, nr_blocks, 1, m, excl));
-}
-
-void
-persistent_data::check_file_exists(string const &file) {
-	struct stat info;
-	int r = ::stat(file.c_str(), &info);
-	if (r)
-		throw runtime_error("Couldn't stat file");
-
-	if (!S_ISREG(info.st_mode))
-		throw runtime_error("Not a regular file");
 }
 
 //----------------------------------------------------------------

--- a/persistent-data/file_utils.h
+++ b/persistent-data/file_utils.h
@@ -9,13 +9,11 @@
 
 // FIXME: move to a different unit
 namespace persistent_data {
-	persistent_data::block_address get_nr_blocks(string const &path, sector_t block_size = MD_BLOCK_SIZE);
-	block_address get_nr_metadata_blocks(string const &path);
+	persistent_data::block_address get_nr_blocks(std::string const &path, sector_t block_size = MD_BLOCK_SIZE);
+	block_address get_nr_metadata_blocks(std::string const &path);
 
 	block_manager<>::ptr open_bm(std::string const &dev_path,
 				     block_manager<>::mode m, bool excl = true);
-
-	void check_file_exists(std::string const &file);
 }
 
 //----------------------------------------------------------------

--- a/persistent-data/space-maps/careful_alloc.cc
+++ b/persistent-data/space-maps/careful_alloc.cc
@@ -21,6 +21,8 @@
 
 #include <boost/shared_ptr.hpp>
 
+using namespace std;
+
 //----------------------------------------------------------------
 
 namespace {

--- a/persistent-data/space-maps/recursive.cc
+++ b/persistent-data/space-maps/recursive.cc
@@ -22,6 +22,7 @@
 #include <list>
 
 using namespace persistent_data;
+using namespace std;
 
 //----------------------------------------------------------------
 

--- a/persistent-data/validators.cc
+++ b/persistent-data/validators.cc
@@ -4,6 +4,8 @@
 #include "persistent-data/errors.h"
 #include "persistent-data/validators.h"
 
+#include <sstream>
+
 using namespace bcache;
 using namespace persistent_data;
 

--- a/thin-provisioning/superblock.cc
+++ b/thin-provisioning/superblock.cc
@@ -3,8 +3,11 @@
 #include "thin-provisioning/superblock.h"
 #include "persistent-data/file_utils.h"
 
+#include <sstream>
+
 using namespace thin_provisioning;
 using namespace superblock_detail;
+using namespace std;
 
 //----------------------------------------------------------------
 

--- a/thin-provisioning/thin_trim.cc
+++ b/thin-provisioning/thin_trim.cc
@@ -1,8 +1,10 @@
 #include <iostream>
 #include <getopt.h>
 #include <sys/ioctl.h>
+#include <sys/stat.h>
 #include <linux/fs.h>
 #include <libgen.h>
+#include <fcntl.h>
 
 #undef BLOCK_SIZE
 


### PR DESCRIPTION
At first, I want to delegate `file_exist()`'s task to `persistent_data::check_file_exists`, but the dependency between those two headers does not allow me to do that. Therefore, I choose to factor out the file-related operations to `base/file-utils.{h,cc}`. The benefits are:

1. Eliminate the potential circular dependency between
   `persistent-data/block.h` and `persistent-data/file_utils.h`,
   if the former one wants to include the latter.
2. Avoid namespace pollution by removing the "using namespace std"
   declaration in `block.tcc`.
3. Correct the header hierarchy: `base/xml_utils.h` now no longer
   depends on the higher-level `persistent-data/file_utils.h`
4. Reduce the code size and compile time
