### PR TITLE
Makefile: Conditional install of thin_trim

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -267,7 +267,6 @@ install: bin/pdata_tools
 	$(INSTALL_DATA) man8/thin_repair.8 $(MANPATH)/man8
 	$(INSTALL_DATA) man8/thin_restore.8 $(MANPATH)/man8
 	$(INSTALL_DATA) man8/thin_rmap.8 $(MANPATH)/man8
-	$(INSTALL_DATA) man8/thin_trim.8 $(MANPATH)/man8
 	$(INSTALL_DATA) man8/thin_metadata_size.8 $(MANPATH)/man8
 	$(INSTALL_DATA) man8/era_check.8 $(MANPATH)/man8
 	$(INSTALL_DATA) man8/era_dump.8 $(MANPATH)/man8
@@ -279,6 +278,7 @@ ifeq ("@DEVTOOLS@", "yes")
 	ln -s -f pdata_tools $(BINDIR)/thin_show_duplicates
 	ln -s -f pdata_tools $(BINDIR)/thin_generate_metadata
 	ln -s -f pdata_tools $(BINDIR)/thin_scan
+	$(INSTALL_DATA) man8/thin_trim.8 $(MANPATH)/man8
 endif
 
 #	$(INSTALL_DATA) man8/era_restore.8 $(MANPATH)/man8

--- a/Makefile.in
+++ b/Makefile.in
@@ -107,10 +107,10 @@ SOURCE=\
 	thin-provisioning/thin_repair.cc \
 	thin-provisioning/thin_restore.cc \
 	thin-provisioning/thin_rmap.cc \
-	thin-provisioning/thin_trim.cc \
 	thin-provisioning/xml_format.cc
 
 DEVTOOLS_SOURCE=\
+	thin-provisioning/thin_trim.cc \
 	thin-provisioning/thin_ll_dump.cc \
 	thin-provisioning/thin_ll_restore.cc \
 	thin-provisioning/thin_show_duplicates.cc \
@@ -249,8 +249,6 @@ install: bin/pdata_tools
 	ln -s -f pdata_tools $(BINDIR)/thin_repair
 	ln -s -f pdata_tools $(BINDIR)/thin_restore
 	ln -s -f pdata_tools $(BINDIR)/thin_rmap
-	ln -s -f pdata_tools $(BINDIR)/thin_show_duplicates
-	ln -s -f pdata_tools $(BINDIR)/thin_trim
 	ln -s -f pdata_tools $(BINDIR)/thin_metadata_size
 	ln -s -f pdata_tools $(BINDIR)/era_check
 	ln -s -f pdata_tools $(BINDIR)/era_dump
@@ -275,6 +273,8 @@ install: bin/pdata_tools
 	$(INSTALL_DATA) man8/era_dump.8 $(MANPATH)/man8
 	$(INSTALL_DATA) man8/era_invalidate.8 $(MANPATH)/man8
 ifeq ("@DEVTOOLS@", "yes")
+	ln -s -f pdata_tools $(BINDIR)/thin_show_duplicates
+	ln -s -f pdata_tools $(BINDIR)/thin_trim
 	ln -s -f pdata_tools $(BINDIR)/thin_ll_dump
 	ln -s -f pdata_tools $(BINDIR)/thin_show_duplicates
 	ln -s -f pdata_tools $(BINDIR)/thin_generate_metadata


### PR DESCRIPTION
...and thin_show_duplicates symlinks.

The support for these is built only if --enable-dev-tools is used in
configure, thus we should install the symlinks conditionally.

Hi Joe, make install is creating a non working symlinks at the moment. Shall we remove those altogether?

I have not tested the moved thin_trim.cc yet.

-- Martian