### PR TITLE
Fix build with libc++ by disambiguating std::bitset away.

### DIFF
--- a/era/restore_emitter.cc
+++ b/era/restore_emitter.cc
@@ -52,7 +52,7 @@ namespace {
 			in_writeset_ = true;
 			era_ = era;
 
-			bits_.reset(new bitset(*md_.tm_));
+			bits_.reset(new persistent_data::bitset(*md_.tm_));
 			bits_->grow(nr_bits, false);
 		}
 


### PR DESCRIPTION
Note that clang++ has a lot more warnings; this is just to fix the build.  Tested on Gentoo Linux with clang-4.0.1 -stdlib=libc++ and gcc 7.2.0 (with libstdc++).