### PR TITLE
Detect XML in *_check tools

### DIFF
--- a/caching/superblock.cc
+++ b/caching/superblock.cc
@@ -365,7 +365,7 @@ caching::check_superblock(superblock const &sb,
 
 	if (sb.magic != SUPERBLOCK_MAGIC) {
 		ostringstream msg;
-		msg << "magic in incorrect: " << sb.magic;
+		msg << "magic is incorrect: " << sb.magic;
 		visitor.visit(superblock_invalid(msg.str()));
 	}
 

--- a/era/superblock.cc
+++ b/era/superblock.cc
@@ -283,7 +283,7 @@ era::check_superblock(superblock const &sb,
 
 	if (sb.magic != SUPERBLOCK_MAGIC) {
 		ostringstream msg;
-		msg << "magic in incorrect: " << sb.magic;
+		msg << "magic is incorrect: " << sb.magic;
 		visitor.visit(superblock_invalid(msg.str()));
 	}
 

--- a/functional-tests/cache-functional-tests.scm
+++ b/functional-tests/cache-functional-tests.scm
@@ -133,12 +133,18 @@
         (cache-restore "-i" xml "-o" md "--debug-override-metadata-version" "12345")
         (run-fail "cache_check" md))))
 
-  (define-scenario (cache-check dont-repair-xml)
-    "Fails gracefully if run on XML rather than metadata"
+  (define-scenario (cache-check tiny-metadata)
+    "Prints helpful message in case XML metadata given"
     (with-cache-xml (xml)
-      (with-empty-metadata (md)
-        (receive (_ stderr) (run-fail "cache_check " xml)
-          #t))))
+      (receive (_ stderr) (run-fail "cache_check" xml)
+        (assert-starts-with "Metadata device/file too small.  Is this binary metadata?" stderr))))
+
+  (define-scenario (cache-check spot-accidental-xml-data)
+    "Prints helpful message if XML metadata given"
+    (with-cache-xml (xml)
+      (system (fmt #f "man bash >> " xml))
+      (receive (_ stderr) (run-fail "cache_check" xml)
+        (assert-matches ".*This looks like XML.  cache_check only checks the binary metadata format." stderr))))
 
   ;;;-----------------------------------------------------------
   ;;; cache_restore scenarios

--- a/functional-tests/era-functional-tests.scm
+++ b/functional-tests/era-functional-tests.scm
@@ -107,6 +107,19 @@
         (assert-eof stdout)
         (assert-eof stderr))))
 
+  (define-scenario (era-check tiny-metadata)
+    "Prints helpful message in case XML metadata given"
+    (with-era-xml (xml)
+      (receive (_ stderr) (run-fail "era_check" xml)
+        (assert-starts-with "Metadata device/file too small.  Is this binary metadata?" stderr))))
+
+  (define-scenario (era-check spot-accidental-xml-data)
+    "Prints helpful message if XML metadata given"
+    (with-era-xml (xml)
+      (system (fmt #f "man bash >> " xml))
+      (receive (_ stderr) (run-fail "era_check" xml)
+        (assert-matches ".*This looks like XML.  era_check only checks the binary metadata format." stderr))))
+
   ;;;-----------------------------------------------------------
   ;;; era_restore scenarios
   ;;;-----------------------------------------------------------

--- a/persistent-data/file_utils.cc
+++ b/persistent-data/file_utils.cc
@@ -7,6 +7,7 @@
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <fcntl.h>
+#include <string.h>
 #include <sstream>
 #include <unistd.h>
 
@@ -16,6 +17,14 @@ using namespace persistent_data;
 using namespace std;
 
 //----------------------------------------------------------------
+
+bool
+persistent_data::check_for_xml(block_manager<>::ptr bm) {
+	block_manager<>::read_ref b = bm->read_lock(0);
+	const char *data = reinterpret_cast<const char *>(b.data());
+	return (!strncmp(data, "<superblock", 11) || !strncmp(data, "<?xml", 5)
+	                       || !strncmp(data, "<!DOCTYPE", 9));
+}
 
 persistent_data::block_address
 persistent_data::get_nr_blocks(std::string const &path, sector_t block_size)

--- a/persistent-data/file_utils.h
+++ b/persistent-data/file_utils.h
@@ -10,6 +10,7 @@
 
 // FIXME: move to a different unit
 namespace persistent_data {
+	bool check_for_xml(block_manager<>::ptr bm);
 	persistent_data::block_address get_nr_blocks(std::string const &path, sector_t block_size = MD_BLOCK_SIZE);
 	block_address get_nr_metadata_blocks(std::string const &path);
 

--- a/thin-provisioning/thin_check.cc
+++ b/thin-provisioning/thin_check.cc
@@ -190,12 +190,6 @@ namespace {
 		return err;
 	}
 
-	void check_for_xml(block_manager<>::ptr bm, nested_output &out) {
-		block_manager<>::read_ref b = bm->read_lock(superblock_detail::SUPERBLOCK_LOCATION);
-		if (!strncmp(reinterpret_cast<const char *>(b.data()), "<superblock", 10))
-			out << "This looks like XML.  thin_check only checks the binary metadata format." << end_message();
-	}
-
 	block_address mapping_root(superblock_detail::superblock const &sb, flags const &fs)
 	{
 		return fs.override_mapping_root ? *fs.override_mapping_root : sb.data_mapping_root_;
@@ -225,7 +219,8 @@ namespace {
 		}
 
 		if (sb_rep.get_error() == FATAL) {
-			check_for_xml(bm, out);
+			if (check_for_xml(bm))
+				out << "This looks like XML.  thin_check only checks the binary metadata format." << end_message();
 			return FATAL;
 		}
 


### PR DESCRIPTION
* not tested: some people complained about upstream ruby and new C++, but chez scheme? Rather an exotic implementation...
* not sure *persistent-data/file_utils.cc* is the best location for `check_for_xml`
* changed `bm->read_lock` to read from offset 0 when detecting file type instead of `superblock_detail::SUPERBLOCK_LOCATION` (which happens to be 0 too)