### PR TITLE
[functional-tests] fix build with testing disabled

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -21,8 +21,13 @@ V=@
 PROGRAMS=\
 	bin/pdata_tools
 
+ifeq ("@TESTING@", "yes")
+TESTLIBS=\
+	lib/libft.so
+endif
+
 .PHONY: all
-all: $(PROGRAMS) lib/libft.so
+all: $(PROGRAMS) $(TESTLIBS)
 
 SOURCE=\
 	base/output_file_requirements.cc \


### PR DESCRIPTION
The rule for lib/libft.so is only enabled with --enable-testing,
so the default target shouldn't depend unconditionally on it.
With the default configure options, the build failed with:
make: *** No rule to make target 'lib/libft.so', needed by 'all'.  Stop.