### PR TITLE
Add autoconf step to Building instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ There are more requirements for testing, detailed below.
 Building
 ========
 
+    autoconf
     ./configure
     make
     sudo make install


### PR DESCRIPTION
The configure script doesn't exist until autoconf is run.

Signed-off-by: Todd Gill <tgill@redhat.com>