### PR TITLE
[space-map-disk] fix the number of free blocks

### DIFF
--- a/persistent-data/space-maps/disk.cc
+++ b/persistent-data/space-maps/disk.cc
@@ -422,7 +422,7 @@ namespace {
 				index_entry ie;
 				ie.blocknr_ = wr.get_location();
 				ie.nr_free_ = i == (bitmap_count - 1) ?
-					(nr_blocks % ENTRIES_PER_BLOCK) : ENTRIES_PER_BLOCK;
+					(nr_blocks - ENTRIES_PER_BLOCK * i) : ENTRIES_PER_BLOCK;
 				ie.none_free_before_ = 0;
 
 				indexes_->save_ie(i, ie);
@@ -462,7 +462,7 @@ namespace {
 			unsigned nr_indexes = div_up<block_address>(nr_blocks_, ENTRIES_PER_BLOCK);
 
 			for (unsigned i = 0; i < nr_indexes; i++) {
-				unsigned hi = (i == nr_indexes - 1) ? (nr_blocks_ % ENTRIES_PER_BLOCK) : ENTRIES_PER_BLOCK;
+				unsigned hi = (i == nr_indexes - 1) ? (nr_blocks_ - ENTRIES_PER_BLOCK * i) : ENTRIES_PER_BLOCK;
 				index_entry ie = indexes_->find_ie(i);
 				bitmap bm(tm_, ie, bitmap_validator_);
 				bm.iterate(i * ENTRIES_PER_BLOCK, hi, wrapper);

--- a/thin-provisioning/metadata.cc
+++ b/thin-provisioning/metadata.cc
@@ -96,7 +96,7 @@ metadata::metadata(block_manager<>::ptr bm, open_type ot,
 		sb_.device_details_root_ = details_->get_root();
 		sb_.data_block_size_ = data_block_size;
 		sb_.metadata_block_size_ = MD_BLOCK_SIZE >> SECTOR_SHIFT;
-		sb_.metadata_nr_blocks_ = tm_->get_bm()->get_nr_blocks();
+		sb_.metadata_nr_blocks_ = metadata_sm_->get_nr_blocks();
 
 		break;
 	}


### PR DESCRIPTION
1. Fix the number of free blocks in the last `index_entry`, for the case that the number of blocks is a multiple of `ENTRIES_PER_BLOCK`. I also noticed that the kernel generates the same `nr_free` value for all the `disk_index_entry`. Is it safe?
```
// in kernel sm_ll_extend()
idx.nr_free = cpu_to_le32(ll->entries_per_block);
```
2. Fix `superblock::nr_metadata_blocks_` to be the truncated size.