### PR TITLE
Fix musl build

### DIFF
--- a/block-cache/io_engine.h
+++ b/block-cache/io_engine.h
@@ -10,13 +10,17 @@
 #include <libaio.h>
 #include <vector>
 
+#include <limits.h>
+#ifndef PAGE_SIZE
+#define PAGE_SIZE sysconf(_SC_PAGE_SIZE)
+#endif
+
 //----------------------------------------------------------------
 
 namespace bcache {
 	using sector_t = uint64_t;
 
 	unsigned const SECTOR_SHIFT = 9;
-	unsigned const PAGE_SIZE = 4096;
 
 	// Virtual base class to aid unit testing
 	class io_engine {

--- a/unit-tests/io_engine_t.cc
+++ b/unit-tests/io_engine_t.cc
@@ -23,6 +23,10 @@
 
 
 #include <fcntl.h>
+#include <limits.h>
+#ifndef PAGE_SIZE
+#define PAGE_SIZE sysconf(_SC_PAGE_SIZE)
+#endif
 
 using namespace boost;
 using namespace std;
@@ -33,7 +37,6 @@ using namespace testing;
 
 namespace {
 	unsigned const MAX_IO = 64;
-	unsigned const PAGE_SIZE = 4096;
 
 	class IOEngineTests : public Test {
 	public:


### PR DESCRIPTION
a) Fix build if limits.h provides definition for PAGE_SIZE, as musl does w/musl per XSI[1] although it's apparently optional [2].
   This value is only provided when it's known to be a constant, to avoid the need to discover the value dynamically.
b) If not using system-provided (kernel headers, or libc headers, or something) use the POSIX approach of querying the value
   dynamically using sysconf(_SC_PAGE_SIZE) instead of hardcoded value that hopefully is correct.
[1] http://pubs.opengroup.org/onlinepubs/9699919799/basedefs/limits.h.html
[2] http://www.openwall.com/lists/musl/2015/09/11/8

This patch originate from:

  https://raw.githubusercontent.com/voidlinux/void-packages/a0ece13ad7ab2aae760e09e41e0459bd999a3695/srcpkgs/thin-provisioning-tools/patches/musl.patch

and was also applied in NixOS:

  https://github.com/NixOS/nixpkgs/pull/40559/

cc @dtzWill