### PR TITLE
[space map] fix accounting of allocatable blocks

### DIFF
--- a/persistent-data/space-maps/careful_alloc.cc
+++ b/persistent-data/space-maps/careful_alloc.cc
@@ -68,10 +68,10 @@ namespace {
 		}
 
 		virtual void dec(block_address b) {
-			sm_->dec(b);
-
-			if (!sm_->get_count(b))
+			if (sm_->get_count(b) == 1)
 				mark_freed(b);
+
+			sm_->dec(b);
 		}
 
 		virtual maybe_block find_free(span_iterator &it) {


### PR DESCRIPTION
Preserve the input block first to avoid reusing it in subsequent
shadow operations, e.g., shadow another block when releasing
a recursive lock. (issue #97)