### PR TITLE
[build] Include boost/optional/optional_io.hpp in  thin-provisioning/emitter.h

### DIFF
--- a/thin-provisioning/emitter.h
+++ b/thin-provisioning/emitter.h
@@ -21,6 +21,8 @@
 
 #include <boost/shared_ptr.hpp>
 #include <boost/optional.hpp>
+#include <boost/optional/optional_io.hpp>
+
 #include <string>
 #include <stdint.h>
 


### PR DESCRIPTION
This fixes following build failure with Boost 1.67.0:
```
In file included from /usr/include/boost/optional/optional.hpp:33,
                 from /usr/include/boost/optional.hpp:15,
                 from ./thin-provisioning/emitter.h:23,
                 from contrib/thin_sexp_emitter.cc:2:
/usr/include/boost/optional/optional.hpp: In instantiation of ‘std::basic_ostream<_CharT, _Traits>& boost::operator<<(std::basic_ostream<_CharT, _Traits>&, const boost::optional_detail::optional_tag&) [with CharType = char; CharTrait = std::char_traits<char>]’:
./base/indented_stream.h:31:9:   required from ‘{anonymous}::indented_stream& {anonymous}::indented_stream::operator<<(const T&) [with T = boost::optional<unsigned int>]’
contrib/thin_sexp_emitter.cc:105:29:   required from ‘void {anonymous}::sexp_emitter::kv(const char*, const T&) [with T = boost::optional<unsigned int>]’
contrib/thin_sexp_emitter.cc:29:21:   required from here
/usr/include/boost/optional/optional.hpp:1481:3: error: static assertion failed: If you want to output boost::optional, include header <boost/optional/optional_io.hpp>
   BOOST_STATIC_ASSERT_MSG(sizeof(CharType) == 0, "If you want to output boost::optional, include header <boost/optional/optional_io.hpp>");
   ^~~~~~~~~~~~~~~~~~~~~~~
make: *** [contrib/Makefile:15: contrib/thin_sexp_emitter.o] Error 1
```

boost/optional/optional_io.hpp exists since at least Boost 1.34.0, so it is
 safe to include in older versions, too.