### PR TITLE
fix compile failed with libc musl

### DIFF
--- a/block-cache/io_engine.h
+++ b/block-cache/io_engine.h
@@ -17,6 +17,10 @@
 
 //----------------------------------------------------------------
 
+// Musl defines
+#ifdef PAGE_SIZE
+#undef PAGE_SIZE
+#endif
 namespace bcache {
 	using sector_t = uint64_t;
 


### PR DESCRIPTION
There is a failure while compiling with libc musl:
[snip]
|./block-cache/io_engine.h:18:17: error: expected
unqualified-id before numeric constant
|  unsigned const PAGE_SIZE = 4096;
[snip]

The musl defeines macro PAGE_SIZE, undef it conditionally
could fix the issue.

http://musl.openwall.narkive.com/tO8vrHdP/why-musl-define-page-size

Signed-off-by: Hongxu Jia <hongxu.jia@windriver.com>