### PR TITLE
Revert "fix compile failed with libc musl (#103)"

### DIFF
--- a/block-cache/io_engine.h
+++ b/block-cache/io_engine.h
@@ -17,10 +17,6 @@
 
 //----------------------------------------------------------------
 
-// Musl defines
-#ifdef PAGE_SIZE
-#undef PAGE_SIZE
-#endif
 namespace bcache {
 	using sector_t = uint64_t;
 


### PR DESCRIPTION
Since the following commit fit musl issue
...
6a7351d Fix musl build (#96)
...

This reverts commit 9311aa648374734cd95e5a624b66ccfc7992cf64.

Signed-off-by: Hongxu Jia <hongxu.jia@windriver.com>