### PR TITLE
[run_set] fix invalid iterator operations

### DIFF
--- a/persistent-data/run_set.h
+++ b/persistent-data/run_set.h
@@ -64,13 +64,13 @@ namespace base {
 
 			typename rset::const_iterator it = runs_.lower_bound(run<T>(v));
 
-			if (it->begin_ == v)
+			if (it != runs_.end() && it->begin_ == v)
 				return true;
 
-			it--;
-
-			if (it != runs_.end())
+			if (it != runs_.begin()) {
+				it--;
 				return it->contains(v);
+			}
 
 			return false;
 		}


### PR DESCRIPTION
Reference: Issue #112 
1. Check the iterator returned by lower_bound search
2. Check the iterator position before decreasing it
