### PR TITLE
[space-map-disk] fix the search range

### DIFF
--- a/persistent-data/space-maps/disk.cc
+++ b/persistent-data/space-maps/disk.cc
@@ -390,7 +390,8 @@ namespace {
 
 					bitmap bm(tm_, ie, bitmap_validator_);
 					unsigned bit_begin = (index == begin_index) ? (begin % ENTRIES_PER_BLOCK) : 0;
-					unsigned bit_end = (index == end_index - 1) ? (end % ENTRIES_PER_BLOCK) : ENTRIES_PER_BLOCK;
+					unsigned bit_end = (index == end_index - 1) ?
+							   (end - ENTRIES_PER_BLOCK * index) : ENTRIES_PER_BLOCK;
 
 					boost::optional<unsigned> maybe_b = bm.find_free(bit_begin, bit_end);
 					if (maybe_b) {


### PR DESCRIPTION
Similar to issue #93, the bit_end will be wrong if the range end is a multiple of ENTRIES_PER_BLOCK.