### PR TITLE
Factor out metadata_checker and btree_damage_visitor.cc

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -80,6 +80,7 @@ SOURCE=\
 	persistent-data/data-structures/bitset.cc \
 	persistent-data/data-structures/bloom_filter.cc \
 	persistent-data/data-structures/btree.cc \
+	persistent-data/data-structures/btree_damage_visitor.cc \
 	persistent-data/data-structures/btree_node_checker.cc \
 	persistent-data/error_set.cc \
 	persistent-data/file_utils.cc \

--- a/configure.ac
+++ b/configure.ac
@@ -112,7 +112,18 @@ AC_ARG_ENABLE(debug, AC_HELP_STRING([--enable-debug], [enable debugging]),
 AC_MSG_RESULT($DEBUG)
 
 if test x$DEBUG = xyes; then
-        CXXDEBUG_FLAG=-g
+        CXXDEBUG_FLAG+=" -g"
+fi
+
+################################################################################
+dnl -- Enable gprof
+AC_MSG_CHECKING(whether to enable gprof)
+AC_ARG_ENABLE(gprof, AC_HELP_STRING([--enable-gprof], [enable gprof]),
+              GPROF=$enableval, GPROF=no)
+AC_MSG_RESULT($GPROF)
+
+if test x$GPROF = xyes; then
+        CXXDEBUG_FLAG+=" -pg"
 fi
 
 ################################################################################

--- a/persistent-data/data-structures/btree_damage_visitor.cc
+++ b/persistent-data/data-structures/btree_damage_visitor.cc
@@ -16,13 +16,13 @@ damage_tracker::bad_node()
 	damaged_ = true;
 }
 
-maybe_range64
+damage_tracker::maybe_run64
 damage_tracker::good_internal(block_address begin)
 {
-	maybe_range64 r;
+	maybe_run64 r;
 
 	if (damaged_) {
-		r = maybe_range64(range64(damage_begin_, begin));
+		r = maybe_run64(run64(damage_begin_, begin));
 		damaged_ = false;
 	}
 
@@ -30,13 +30,13 @@ damage_tracker::good_internal(block_address begin)
 	return r;
 }
 
-maybe_range64
-damage_tracker::good_leaf(uint64_t begin, uint64_t end)
+damage_tracker::maybe_run64
+damage_tracker::good_leaf(block_address begin, block_address end)
 {
-	maybe_range64 r;
+	maybe_run64 r;
 
 	if (damaged_) {
-		r = maybe_range64(range64(damage_begin_, begin));
+		r = maybe_run64(run64(damage_begin_, begin));
 		damaged_ = false;
 	}
 
@@ -44,13 +44,49 @@ damage_tracker::good_leaf(uint64_t begin, uint64_t end)
 	return r;
 }
 
-maybe_range64
+damage_tracker::maybe_run64
 damage_tracker::end()
 {
+	maybe_run64 r;
+
 	if (damaged_)
-		return maybe_range64(damage_begin_);
+		r = maybe_run64(damage_begin_);
 	else
-		return maybe_range64();
+		r = maybe_run64();
+
+	damaged_ = false;
+	damage_begin_ = 0;
+
+	return r;
+}
+
+//----------------------------------------------------------------
+
+path_tracker::path_tracker()
+{
+	// We push an empty path, to ensure there
+	// is always a current_path.
+	paths_.push_back(btree_path());
+}
+
+btree_path const *
+path_tracker::next_path(btree_path const &p)
+{
+	if (p != current_path()) {
+		if (paths_.size() == 2)
+			paths_.pop_front();
+		paths_.push_back(p);
+
+		return &paths_.front();
+	}
+
+	return NULL;
+}
+
+btree_path const &
+path_tracker::current_path() const
+{
+	return paths_.back();
 }
 
 //----------------------------------------------------------------

--- a/persistent-data/data-structures/btree_damage_visitor.h
+++ b/persistent-data/data-structures/btree_damage_visitor.h
@@ -38,57 +38,20 @@ namespace persistent_data {
 		// trackers if you have a multilayer tree.
 		class damage_tracker {
 		public:
-			damage_tracker()
-				: damaged_(false),
-				  damage_begin_(0) {
-			}
+			damage_tracker();
 
 			typedef run<uint64_t> run64;
 			typedef boost::optional<run64> maybe_run64;
 
-			void bad_node() {
-				damaged_ = true;
-			}
+			void bad_node();
 
-			maybe_run64 good_internal(block_address begin) {
-				maybe_run64 r;
-
-				if (damaged_) {
-					r = maybe_run64(run64(damage_begin_, begin));
-					damaged_ = false;
-				}
-
-				damage_begin_ = begin;
-				return r;
-			}
+			maybe_run64 good_internal(block_address begin);
 
 			// remember 'end' is the one-past-the-end value, so
 			// take the last key in the leaf and add one.
-			maybe_run64 good_leaf(block_address begin, block_address end) {
-				maybe_run64 r;
+			maybe_run64 good_leaf(block_address begin, block_address end);
 
-				if (damaged_) {
-					r = maybe_run64(run64(damage_begin_, begin));
-					damaged_ = false;
-				}
-
-				damage_begin_ = end;
-				return r;
-			}
-
-			maybe_run64 end() {
-				maybe_run64 r;
-
-				if (damaged_)
-					r = maybe_run64(damage_begin_);
-				else
-					r = maybe_run64();
-
-				damaged_ = false;
-				damage_begin_ = 0;
-
-				return r;
-			}
+			maybe_run64 end();
 
 		private:
 			bool damaged_;
@@ -99,28 +62,12 @@ namespace persistent_data {
 		// different sub tree (by looking at the btree_path).
 		class path_tracker {
 		public:
-			path_tracker() {
-				// We push an empty path, to ensure there
-				// is always a current_path.
-				paths_.push_back(btree_path());
-			}
+			path_tracker();
 
 			// returns the old path if the tree has changed.
-			btree_path const *next_path(btree_path const &p) {
-				if (p != current_path()) {
-					if (paths_.size() == 2)
-						paths_.pop_front();
-					paths_.push_back(p);
+			btree_path const *next_path(btree_path const &p);
 
-					return &paths_.front();
-				}
-
-				return NULL;
-			}
-
-			btree_path const &current_path() const {
-				return paths_.back();
-			}
+			btree_path const &current_path() const;
 
 		private:
 			std::list<btree_path> paths_;

--- a/thin-provisioning/metadata_checker.h
+++ b/thin-provisioning/metadata_checker.h
@@ -19,142 +19,54 @@
 #ifndef METADATA_CHECKER_H
 #define METADATA_CHECKER_H
 
+#include "base/error_state.h"
+#include "block-cache/block_cache.h"
 #include "persistent-data/block.h"
-#include "persistent-data/error_set.h"
-#include "persistent-data/run.h"
-#include "persistent-data/space_map.h"
-
-#include <deque>
 
 //----------------------------------------------------------------
 
 namespace thin_provisioning {
-	// FIXME: should take a block manager or transaction manager
-	void check_metadata(std::string const &path);
+	struct check_options {
+		enum data_mapping_options {
+			DATA_MAPPING_NONE,
+			DATA_MAPPING_LEVEL1,
+			DATA_MAPPING_LEVEL2,
+		};
 
+		enum metadata_space_map_options {
+			METADATA_SPACE_MAP_NONE,
+			METADATA_SPACE_MAP_FULL,
+		};
 
+		check_options();
 
+		void set_superblock_only();
+		void set_skip_mappings();
+		void set_override_mapping_root(bcache::block_address b);
 
+		data_mapping_options check_data_mappings_;
+		metadata_space_map_options check_metadata_space_map_;
+		boost::optional<bcache::block_address> override_mapping_root_;
+	};
 
+	enum output_options {
+		OUTPUT_NORMAL,
+		OUTPUT_QUIET,
+	};
 
-
-
-
-#if 0
-
-	// Base class for all types of metadata damage.  Used in reporting.
-	class metadata_damage {
+	class metadata_checker {
 	public:
-		typedef boost::shared_ptr<metadata_damage> ptr;
-		virtual ~metadata_damage() {}
-		virtual void visit(metadata_damage_visitor &visitor) const = 0;
+		typedef boost::shared_ptr<metadata_checker> ptr;
 
-		void set_message(std::string const &message);
-		std::string const &get_message() const;
+		virtual ~metadata_checker() {}
 
-	private:
-		std::string message_;
+		virtual base::error_state check() = 0;
 	};
 
-	// FIXME: there's a mix of abstraction here, some classes represent
-	// the actual damage on disk (bad_ref_count), others represent the
-	// repercussions (missing_mapping).  Need to revist, probably once
-	// we've got the reporting layer in.
-
-	class super_block_corruption : public metadata_damage {
-		void visit(metadata_damage_visitor &visitor) const;
-		bool operator ==(super_block_corruption const &rhs) const;
-	};
-
-	typedef base::run<uint64_t> run64;
-
-	struct missing_device_details : public metadata_damage {
-		missing_device_details(run64 missing);
-		virtual void visit(metadata_damage_visitor &visitor) const;
-		bool operator ==(missing_device_details const &rhs) const;
-
-		run64 missing_;
-	};
-
-	struct missing_devices : public metadata_damage {
-		missing_devices(run64 missing);
-		virtual void visit(metadata_damage_visitor &visitor) const;
-		bool operator ==(missing_devices const &rhs) const;
-
-		run64 missing_;
-	};
-
-	struct missing_mappings : public metadata_damage {
-		missing_mappings(uint64_t dev, run64 missing);
-		virtual void visit(metadata_damage_visitor &visitor) const;
-		bool operator ==(missing_mappings const &rhs) const;
-
-		uint64_t dev_;
-		run64 missing_;
-	};
-
-	struct bad_metadata_ref_count : public metadata_damage {
-		bad_metadata_ref_count(block_address b,
-				       ref_t actual,
-				       ref_t expected);
-
-		virtual void visit(metadata_damage_visitor &visitor) const;
-		bool operator ==(bad_metadata_ref_count const &rhs) const;
-
-		block_address b_;
-		ref_t actual_;
-		ref_t expected_;
-	};
-
-	struct bad_data_ref_count : public metadata_damage {
-		bad_data_ref_count(block_address b,
-				   ref_t actual,
-				   ref_t expected);
-
-		virtual void visit(metadata_damage_visitor &visitor) const;
-		bool operator ==(bad_data_ref_count const &rhs) const;
-
-		block_address b_;
-		ref_t actual_;
-		ref_t expected_;
-	};
-
-	struct missing_metadata_ref_counts : public metadata_damage {
-		missing_metadata_ref_counts(run64 missing);
-		virtual void visit(metadata_damage_visitor &visitor) const;
-		bool operator ==(missing_metadata_ref_counts const &rhs) const;
-
-		run64 missing_;
-	};
-
-	struct missing_data_ref_counts : public metadata_damage {
-		missing_data_ref_counts(run64 missing);
-		virtual void visit(metadata_damage_visitor &visitor) const;
-		bool operator ==(missing_data_ref_counts const &rhs) const;
-
-		run64 missing_;
-	};
-
-	class metadata_damage_visitor {
-	public:
-		typedef boost::shared_ptr<metadata_damage_visitor> ptr;
-
-		virtual ~metadata_damage_visitor() {}
-
-		void visit(metadata_damage const &damage);
-		virtual void visit(super_block_corruption const &damage) = 0;
-		virtual void visit(missing_device_details const &damage) = 0;
-		virtual void visit(missing_devices const &damage) = 0;
-		virtual void visit(missing_mappings const &damage) = 0;
-		virtual void visit(bad_metadata_ref_count const &damage) = 0;
-		virtual void visit(bad_data_ref_count const &damage) = 0;
-		virtual void visit(missing_metadata_ref_counts const &damage) = 0;
-		virtual void visit(missing_data_ref_counts const &damage) = 0;
-	};
-
-	typedef std::deque<metadata_damage::ptr> damage_list;
-	typedef boost::shared_ptr<damage_list> damage_list_ptr;
-#endif
+	metadata_checker::ptr
+	create_base_checker(persistent_data::block_manager<>::ptr bm,
+			    check_options const &check_opts,
+			    output_options output_opts);
 }
 
 //----------------------------------------------------------------


### PR DESCRIPTION
Concept
* A `metadata_checker` accept three parameters: the device file, the check_options for selective checking, and the output option.

Thoughts
* Is it good to invoke `print_info()` inside the metadata_checker?
* If we want to make metadata_checker more concise, we could move `check_for_xml()` and `print_info()` to thin_check.cc. On the other hand, if we want to make the components self-contained, then file-size-checking should be done in `open_bm()`
* `struct check_options` looks unstraightforward, and its reusability is uncertain (might not work for further checker variants). A better policy-based approach might be required to do selective checking.