### PR TITLE
Improve performance, and remove unused code

### DIFF
--- a/persistent-data/block.h
+++ b/persistent-data/block.h
@@ -64,8 +64,6 @@ namespace persistent_data {
 			read_ref(read_ref const &rhs);
 			virtual ~read_ref();
 
-			read_ref const &operator =(read_ref const &rhs);
-
 			block_address get_location() const;
 			void const *data() const;
 
@@ -81,8 +79,6 @@ namespace persistent_data {
 			write_ref(block_cache::block &b, unsigned &ref_count);
 			write_ref(write_ref const &rhs);
 			~write_ref();
-
-			write_ref const &operator =(write_ref const &rhs);
 
 			using read_ref::data;
 			void *data();

--- a/persistent-data/block.tcc
+++ b/persistent-data/block.tcc
@@ -48,18 +48,6 @@ namespace persistent_data {
 	}
 
 	template <uint32_t BlockSize>
-	typename block_manager<BlockSize>::read_ref const &
-	block_manager<BlockSize>::read_ref::operator =(read_ref const &rhs)
-	{
-		if (this != &rhs) {
-			b_ = rhs.b_;
-			b_.get();
-		}
-
-		return *this;
-	}
-
-	template <uint32_t BlockSize>
 	block_address
 	block_manager<BlockSize>::read_ref::get_location() const
 	{
@@ -109,18 +97,6 @@ namespace persistent_data {
 			}
 
 			(*ref_count_)--;
-		}
-	}
-
-	template <uint32_t BlockSize>
-	typename block_manager<BlockSize>::write_ref const &
-	block_manager<BlockSize>::write_ref::operator =(write_ref const &rhs)
-	{
-		if (&rhs != this) {
-			read_ref::operator =(rhs);
-			ref_count_ = rhs.ref_count_;
-			if (ref_count_)
-				(*ref_count_)++;
 		}
 	}
 


### PR DESCRIPTION
The `bitmap::find_free()` commit drastically improves the performance of finding free blocks in a fragmented space map. The improvement could be 10x or more while inserting millions of keys. thin_restore and thin_repair do not benefit from this change, since that the space map is not fragmented at the first transaction (i.e., all the blocks are shadowed).

There is still room for improvement. For example:
* Keep track of the "real" free blocks for the new transaction.
* In `sm_disk::find_free()`, avoid breaking a bitmap block into multiple spans, to reduce the number of read_locks, and also avoid accessing the same portion (in terms of 64-bit dereferencing) of a bitmap multiple times.

The first one might have more of an effect. However, I haven't had an idea yet.