### PR TITLE
autoconf: allow a user to override ar

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -185,6 +185,7 @@ ifeq ("@STATIC@", "yes")
 LDFLAGS+=-static
 endif
 
+AR:=@AR@
 INSTALL:=@INSTALL@
 PREFIX:=@prefix@
 BINDIR:=$(DESTDIR)$(PREFIX)/sbin
@@ -234,7 +235,7 @@ endif
 lib/libpdata.a: $(OBJECTS) $(EMITTERS)
 	@echo "    [AR]  $<"
 	@mkdir -p $(dir $@)
-	$(V)ar -rv $@ $(OBJECTS) $(EMITTERS) > /dev/null 2>&1
+	$(V)$(AR) -rv $@ $(OBJECTS) $(EMITTERS) > /dev/null 2>&1
 
 bin/pdata_tools: $(OBJECTS) $(EMITTERS)
 	@echo "    [LD]  $@"

--- a/configure.ac
+++ b/configure.ac
@@ -188,6 +188,7 @@ VERSION_MINOR=`echo "$VER" | $AWK -F '.' '{print $2}'`
 VERSION_PATCHLEVEL=`echo "$VER" | $AWK -F '[[(.]]' '{print $3}'`
 
 ################################################################
+AC_SUBST(AR)
 AC_SUBST(CXXDEBUG_FLAG)
 AC_SUBST(CXXOPTIMISE_FLAG)
 AC_SUBST(CXX_STRERROR_FLAG)

--- a/contrib/Makefile.in
+++ b/contrib/Makefile.in
@@ -16,7 +16,7 @@ contrib/%.o: contrib/%.cc
 
 contrib/%.a: contrib/%.o
 	$(V)echo "    [AR] $@"
-	$(V)ar rcs $@ $^
+	$(V)$(AR) rcs $@ $^
 
 contrib/%.so: contrib/%.a
 	$(V)echo "    [LD] $@"

--- a/unit-tests/Makefile.in
+++ b/unit-tests/Makefile.in
@@ -36,11 +36,11 @@ GMOCK_DEPS=\
 lib/libgmock.a: $(GMOCK_DEPS)
 	@echo "    [CXX] gtest"
 	@mkdir -p lib
-	$(V)g++ $(GMOCK_INCLUDES) -I$(GMOCK_DIR)/googletest -std=c++11 -c $(GMOCK_DIR)/googletest/src/gtest-all.cc
+	$(V) $(CXX) $(GMOCK_INCLUDES) -I$(GMOCK_DIR)/googletest -std=c++11 -c $(GMOCK_DIR)/googletest/src/gtest-all.cc
 	@echo "    [CXX] gmock"
-	$(V)g++ $(GMOCK_INCLUDES) -I$(GMOCK_DIR)/googlemock -std=c++11 -c $(GMOCK_DIR)/googlemock/src/gmock-all.cc
+	$(V) $(CXX) $(GMOCK_INCLUDES) -I$(GMOCK_DIR)/googlemock -std=c++11 -c $(GMOCK_DIR)/googlemock/src/gmock-all.cc
 	@echo "    [AR]  $<"
-	$(V)ar -rv lib/libgmock.a gtest-all.o gmock-all.o > /dev/null 2>&1
+	$(V)$(AR) -rv lib/libgmock.a gtest-all.o gmock-all.o > /dev/null 2>&1
 
 TEST_SOURCE=\
 	unit-tests/gmock_main.cc \


### PR DESCRIPTION
This is used on specific buildchains (nixos static builds for example).