### PR TITLE
[build] Fix the default value for the AR variable (#145)

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -149,6 +149,7 @@ endif
 
 CC:=@CC@
 CXX:=@CXX@
+AR:=@AR@
 STRIP:=@STRIP@
 OBJECTS:=$(subst .cc,.o,$(SOURCE))
 
@@ -187,7 +188,6 @@ ifeq ("@STATIC@", "yes")
 LDFLAGS+=-static
 endif
 
-AR:=@AR@
 INSTALL:=@INSTALL@
 PREFIX:=@prefix@
 BINDIR:=$(DESTDIR)$(PREFIX)/sbin

--- a/configure.ac
+++ b/configure.ac
@@ -44,6 +44,9 @@ AC_PROG_INSTALL
 AC_DEFUN([AC_PROG_STRIP], [AC_CHECK_TOOL(STRIP, strip, :)])
 AC_PROG_STRIP
 AC_ARG_VAR(STRIP, [Command for discarding symbols from object files])
+AC_DEFUN([AC_PROG_AR], [AC_CHECK_TOOL(AR, ar, :)])
+AC_PROG_AR
+AC_ARG_VAR(AR, [Program that maintains archive files])
 
 ################################################################
 dnl -- Check for large file support

--- a/unit-tests/Makefile.in
+++ b/unit-tests/Makefile.in
@@ -40,7 +40,7 @@ lib/libgmock.a: $(GMOCK_DEPS)
 	@echo "    [CXX] gmock"
 	$(V) $(CXX) $(GMOCK_INCLUDES) -I$(GMOCK_DIR)/googlemock -std=c++11 -c $(GMOCK_DIR)/googlemock/src/gmock-all.cc
 	@echo "    [AR]  $<"
-	$(V)$(AR) -rv lib/libgmock.a gtest-all.o gmock-all.o > /dev/null 2>&1
+	$(V) $(AR) -rv lib/libgmock.a gtest-all.o gmock-all.o > /dev/null 2>&1
 
 TEST_SOURCE=\
 	unit-tests/gmock_main.cc \
@@ -89,7 +89,7 @@ TEST_OBJECTS=$(subst .cc,.gmo,$(TEST_SOURCE))
 unit-tests/unit_tests: $(TEST_OBJECTS) lib/libgmock.a lib/libpdata.a
 	@echo "    [LD]  $<"
 	@mkdir -p $(dir $@)
-	$(V)g++ $(CXXFLAGS) $(LDFLAGS) -o $@ $(TEST_OBJECTS) $(LIBS) $(GMOCK_LIBS) $(LIBEXPAT)
+	$(V) $(CXX) $(CXXFLAGS) $(LDFLAGS) -o $@ $(TEST_OBJECTS) $(LIBS) $(GMOCK_LIBS) $(LIBEXPAT)
 
 .PHONY: unit-test
 


### PR DESCRIPTION
The previous patch depends on the shell/environment variable `AR`, thus the string `AR` in Makefile won't be substituted if the corresponding shell/environment variable is not set.