### PR TITLE
thin-provisioning: avoid NULL dereference in run

### DIFF
--- a/thin-provisioning/thin_dump.cc
+++ b/thin-provisioning/thin_dump.cc
@@ -197,13 +197,19 @@ thin_dump_cmd::run(int argc, char **argv)
 			break;
 
 		case 1:
-			dev_id = strtoull(optarg, &end_ptr, 10);
-			if (end_ptr == optarg) {
-				cerr << "couldn't parse <dev-id>\n";
+			if (optarg) {
+				dev_id = strtoull(optarg, &end_ptr, 10);
+				if (end_ptr == optarg) {
+					cerr << "couldn't parse <dev-id>\n";
+					usage(cerr);
+					return 1;
+				}
+				flags.opts.select_dev(dev_id);
+			} else {
+				cerr << "No input argument provided\n";
 				usage(cerr);
 				return 1;
 			}
-			flags.opts.select_dev(dev_id);
 			break;
 
 		case 2:


### PR DESCRIPTION
If the optarg is NULL, there will be error in strtoull.
Here, we check optarg before call strtoull like case 'm'.

Signed-off-by: Lixiaokeng <lixiaokeng@huawei.com>
Signed-off-by: Zhiqiang Liu <liuzhiqiang26@huawei.com>