### PR TITLE
Fix bugs in array iteration and text outputs

### DIFF
--- a/src/cache/superblock.rs
+++ b/src/cache/superblock.rs
@@ -104,7 +104,7 @@ fn unpack(data: &[u8]) -> IResult<&[u8], Superblock> {
             },
             block,
             version,
-            policy_name: policy_name.to_vec(),
+            policy_name: policy_name.splitn(2, |c| *c == 0).next().unwrap().to_vec(),
             policy_version: vec![vsn_major, vsn_minor, vsn_patch],
             policy_hint_size,
             metadata_sm_root: metadata_sm_root.to_vec(),

--- a/src/cache/xml.rs
+++ b/src/cache/xml.rs
@@ -119,7 +119,7 @@ impl<W: Write> MetadataVisitor for XmlWriter<W> {
     }
 
     fn mapping(&mut self, m: &Map) -> Result<Visit> {
-        let tag = b"map";
+        let tag = b"mapping";
         let mut elem = BytesStart::owned(tag.to_vec(), tag.len());
         elem.push_attribute(mk_attr(b"cache_block", m.cblock));
         elem.push_attribute(mk_attr(b"origin_block", m.oblock));

--- a/src/pdata/array_walker.rs
+++ b/src/pdata/array_walker.rs
@@ -53,7 +53,9 @@ impl<'a, V: Unpack + Copy> NodeVisitor<u64> for BlockValueVisitor<'a, V> {
         keys: &[u64],
         values: &[u64],
     ) -> btree::Result<()> {
-        let mut path = path.to_vec();
+        if keys.is_empty() {
+            return Ok(());
+        }
 
         // The ordering of array indices had been verified in unpack_node(),
         // thus checking the upper bound implies key continuity among siblings.
@@ -86,6 +88,7 @@ impl<'a, V: Unpack + Copy> NodeVisitor<u64> for BlockValueVisitor<'a, V> {
                             array_errs.push(array::io_err(&path, values[i]).index_context(keys[i]));
                         }
                         Ok(b) => {
+                            let mut path = path.to_vec();
                             path.push(b.loc);
                             match unpack_array_block::<V>(&path, b.get_data()) {
                                 Ok(array_block) => {

--- a/src/pdata/bitset.rs
+++ b/src/pdata/bitset.rs
@@ -58,10 +58,9 @@ impl ArrayVisitor<u64> for BitsetVisitor {
             )));
         }
 
-        for i in 0..b.header.nr_entries as usize {
+        for bits in b.values.iter() {
             let end: usize = std::cmp::min(begin + 64, self.nr_bits as usize);
             let mut mask = 1;
-            let bits = b.values[i];
 
             for bi in begin..end {
                 self.bits.lock().unwrap().set(bi, bits & mask != 0);


### PR DESCRIPTION
- Fix array indexing
- Fix panic on empty array
- Remove trailing null characters from the policy name
- Change XML tag naming for backward compatibility