### PR TITLE
Clear thin superblock flags in restored metadata

### DIFF
--- a/thin-provisioning/restore_emitter.cc
+++ b/thin-provisioning/restore_emitter.cc
@@ -57,7 +57,7 @@ namespace {
 			memcpy(&sb.uuid_, uuid.c_str(), std::min(sizeof(sb.uuid_), uuid.length()));
 			sb.time_ = time;
 			sb.trans_id_ = trans_id;
-			sb.flags_ = flags ? *flags : 0;
+			sb.flags_ = 0;
 			sb.version_ = version ? *version : 1;
 			sb.data_block_size_ = data_block_size;
 			sb.metadata_snap_ = metadata_snap ? *metadata_snap : 0;


### PR DESCRIPTION
It is not necessary to reserve the superblock flags especially the needs_check one, although the propagated flags could be cleared by thin_check during LVM pool activation.