### PR TITLE
Fix restoration tools

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,3 +41,6 @@ quickcheck_macros = "0.9"
 
 [profile.release]
 debug = true
+
+[features]
+rust_tests = []

--- a/src/bin/cache_dump.rs
+++ b/src/bin/cache_dump.rs
@@ -10,24 +10,38 @@ use thinp::cache::dump::{dump, CacheDumpOptions};
 fn main() {
     let parser = App::new("cache_dump")
         .version(thinp::version::tools_version())
-        .arg(
-            Arg::with_name("INPUT")
-                .help("Specify the input device to check")
-                .required(true)
-                .index(1),
-        )
+        .about("Dump the cache metadata to stdout in XML format")
         .arg(
             Arg::with_name("REPAIR")
-                .help("")
-                .long("repair")
-                .value_name("REPAIR"),
+                .help("Repair the metadata whilst dumping it")
+                .short("r")
+                .long("repair"),
+        )
+        .arg(
+            Arg::with_name("OUTPUT")
+                .help("Specify the output file rather than stdout")
+                .short("o")
+                .long("output")
+                .value_name("OUTPUT"),
+        )
+        .arg(
+            Arg::with_name("INPUT")
+                .help("Specify the input device to dump")
+                .required(true)
+                .index(1),
         );
 
     let matches = parser.get_matches();
     let input_file = Path::new(matches.value_of("INPUT").unwrap());
+    let output_file = if matches.is_present("OUTPUT") {
+        Some(Path::new(matches.value_of("OUTPUT").unwrap()))
+    } else {
+        None
+    };
 
     let opts = CacheDumpOptions {
-        dev: &input_file,
+        input: input_file,
+        output: output_file,
         async_io: false,
         repair: matches.is_present("REPAIR"),
     };

--- a/src/bin/thin_check.rs
+++ b/src/bin/thin_check.rs
@@ -25,14 +25,12 @@ fn main() {
         .arg(
             Arg::with_name("SB_ONLY")
                 .help("Only check the superblock.")
-                .long("super-block-only")
-                .value_name("SB_ONLY"),
+                .long("super-block-only"),
         )
         .arg(
             Arg::with_name("SKIP_MAPPINGS")
                 .help("Don't check the mapping tree")
-                .long("skip-mappings")
-                .value_name("SKIP_MAPPINGS"),
+                .long("skip-mappings"),
         )
         .arg(
             Arg::with_name("AUTO_REPAIR")
@@ -47,7 +45,7 @@ fn main() {
         .arg(
             Arg::with_name("CLEAR_NEEDS_CHECK")
                 .help("Clears the 'needs_check' flag in the superblock")
-                .long("clear-needs-check"),
+                .long("clear-needs-check-flag"),
         )
         .arg(
             Arg::with_name("OVERRIDE_MAPPING_ROOT")

--- a/src/cache/restore.rs
+++ b/src/cache/restore.rs
@@ -3,7 +3,6 @@ use anyhow::{anyhow, Result};
 use std::convert::TryInto;
 use std::fs::OpenOptions;
 use std::io::Cursor;
-use std::ops::Deref;
 use std::path::Path;
 use std::sync::Arc;
 
@@ -230,8 +229,7 @@ impl<'a> MetadataVisitor for Restorer<'a> {
 fn build_metadata_sm(w: &mut WriteBatcher) -> Result<Vec<u8>> {
     let mut sm_root = vec![0u8; SPACE_MAP_ROOT_SIZE];
     let mut cur = Cursor::new(&mut sm_root);
-    let sm_without_meta = clone_space_map(w.sm.lock().unwrap().deref())?;
-    let r = write_metadata_sm(w, sm_without_meta.deref())?;
+    let r = write_metadata_sm(w)?;
     r.pack(&mut cur)?;
 
     Ok(sm_root)

--- a/src/pdata/array_builder.rs
+++ b/src/pdata/array_builder.rs
@@ -125,7 +125,7 @@ impl<V: Unpack + Pack + Clone + Default> ArrayBuilder<V> {
 
     pub fn complete(self, w: &mut WriteBatcher) -> Result<u64> {
         let blocks = self.block_builder.complete(w)?;
-        let mut index_builder = Builder::<u64>::new(Box::new(NoopRC {}));
+        let mut index_builder = BTreeBuilder::<u64>::new(Box::new(NoopRC {}));
 
         for (i, b) in blocks.iter().enumerate() {
             index_builder.push_value(w, i as u64, *b)?;

--- a/src/pdata/space_map.rs
+++ b/src/pdata/space_map.rs
@@ -152,16 +152,6 @@ pub fn core_sm_without_mutex(nr_entries: u64, max_count: u32) -> Box<dyn SpaceMa
     }
 }
 
-// FIXME: replace it by using the Clone trait
-pub fn clone_space_map(src: &dyn SpaceMap) -> Result<Box<dyn SpaceMap>> {
-    let nr_blocks = src.get_nr_blocks()?;
-    let mut dest = Box::new(CoreSpaceMap::<u32>::new(nr_blocks));
-    for i in 0..nr_blocks {
-        dest.set(i, src.get(i)?)?;
-    }
-    Ok(dest)
-}
-
 //------------------------------------------
 
 // This in core space map can only count to one, useful when walking

--- a/src/pdata/space_map.rs
+++ b/src/pdata/space_map.rs
@@ -24,9 +24,16 @@ pub trait SpaceMap {
         Ok(old == 1)
     }
 
-    /// Finds a block with a zero reference count.  Increments the
-    /// count.
+    /// Finds a block with a zero reference count. Increments the count.
+    /// Returns Ok(None) if no free block (ENOSPC)
+    /// Returns Err on fatal error
     fn alloc(&mut self) -> Result<Option<u64>>;
+
+    /// Finds a free block within the range
+    fn find_free(&mut self, begin: u64, end: u64) -> Result<Option<u64>>;
+
+    /// Returns the position where allocation starts
+    fn get_alloc_begin(&self) -> Result<u64>;
 }
 
 pub type ASpaceMap = Arc<Mutex<dyn SpaceMap + Sync + Send>>;
@@ -35,7 +42,7 @@ pub type ASpaceMap = Arc<Mutex<dyn SpaceMap + Sync + Send>>;
 
 pub struct CoreSpaceMap<T> {
     nr_allocated: u64,
-    first_free: u64,
+    alloc_begin: u64,
     counts: Vec<T>,
 }
 
@@ -46,7 +53,7 @@ where
     pub fn new(nr_entries: u64) -> CoreSpaceMap<V> {
         CoreSpaceMap {
             nr_allocated: 0,
-            first_free: 0,
+            alloc_begin: 0,
             counts: vec![V::default(); nr_entries as usize],
         }
     }
@@ -77,9 +84,6 @@ where
             self.nr_allocated += 1;
         } else if old != V::from(0u8) && v == 0 {
             self.nr_allocated -= 1;
-            if b < self.first_free {
-                self.first_free = b;
-            }
         }
 
         Ok(old.into())
@@ -99,17 +103,32 @@ where
     }
 
     fn alloc(&mut self) -> Result<Option<u64>> {
-        for b in self.first_free..(self.counts.len() as u64) {
-            if self.counts[b as usize] == V::from(0u8) {
-                self.counts[b as usize] = V::from(1u8);
-                self.first_free = b + 1;
-                self.nr_allocated += 1;
-                return Ok(Some(b));
+        let mut b = self.find_free(self.alloc_begin, self.counts.len() as u64)?;
+        if b.is_none() {
+            b = self.find_free(0, self.alloc_begin)?;
+            if b.is_none() {
+                return Ok(None);
             }
         }
 
-        self.first_free = self.counts.len() as u64;
+        self.counts[b.unwrap() as usize] = V::from(1u8);
+        self.nr_allocated += 1;
+        self.alloc_begin = b.unwrap() + 1;
+
+        Ok(b)
+    }
+
+    fn find_free(&mut self, begin: u64, end: u64) -> Result<Option<u64>> {
+        for b in begin..end {
+            if self.counts[b as usize] == V::from(0u8) {
+                return Ok(Some(b));
+            }
+        }
         Ok(None)
+    }
+
+    fn get_alloc_begin(&self) -> Result<u64> {
+        Ok(self.alloc_begin as u64)
     }
 }
 
@@ -150,7 +169,7 @@ pub fn clone_space_map(src: &dyn SpaceMap) -> Result<Box<dyn SpaceMap>> {
 // aren't interested in counting how many times we've visited.
 pub struct RestrictedSpaceMap {
     nr_allocated: u64,
-    first_free: usize,
+    alloc_begin: usize,
     counts: FixedBitSet,
 }
 
@@ -159,7 +178,7 @@ impl RestrictedSpaceMap {
         RestrictedSpaceMap {
             nr_allocated: 0,
             counts: FixedBitSet::with_capacity(nr_entries as usize),
-            first_free: 0,
+            alloc_begin: 0,
         }
     }
 }
@@ -192,9 +211,6 @@ impl SpaceMap for RestrictedSpaceMap {
         } else {
             if old {
                 self.nr_allocated -= 1;
-                if b < self.first_free as u64 {
-                    self.first_free = b as usize;
-                }
             }
             self.counts.set(b as usize, false);
         }
@@ -213,16 +229,32 @@ impl SpaceMap for RestrictedSpaceMap {
     }
 
     fn alloc(&mut self) -> Result<Option<u64>> {
-        for b in self.first_free..self.counts.len() {
-            if !self.counts.contains(b) {
-                self.counts.insert(b);
-                self.first_free = b + 1;
-                return Ok(Some(b as u64));
+        let mut b = self.find_free(self.alloc_begin as u64, self.counts.len() as u64)?;
+        if b.is_none() {
+            b = self.find_free(0, self.alloc_begin as u64)?;
+            if b.is_none() {
+                return Ok(None);
             }
         }
 
-        self.first_free = self.counts.len();
+        self.counts.insert(b.unwrap() as usize);
+        self.nr_allocated += 1;
+        self.alloc_begin = b.unwrap() as usize + 1;
+
+        Ok(b)
+    }
+
+    fn find_free(&mut self, begin: u64, end: u64) -> Result<Option<u64>> {
+        for b in begin..end {
+            if !self.counts.contains(b as usize) {
+                return Ok(Some(b));
+            }
+        }
         Ok(None)
+    }
+
+    fn get_alloc_begin(&self) -> Result<u64> {
+        Ok(self.alloc_begin as u64)
     }
 }
 

--- a/src/pdata/space_map_checker.rs
+++ b/src/pdata/space_map_checker.rs
@@ -190,14 +190,6 @@ fn gather_metadata_index_entries(
 ) -> Result<Vec<IndexEntry>> {
     let b = engine.read(bitmap_root)?;
     let entries = unpack::<MetadataIndex>(b.get_data())?.indexes;
-
-    // Filter out unused entries with block 0
-    let entries: Vec<IndexEntry> = entries
-        .iter()
-        .take_while(|e| e.blocknr != 0)
-        .cloned()
-        .collect();
-
     metadata_sm.lock().unwrap().inc(bitmap_root, 1)?;
     inc_entries(&metadata_sm, &entries[0..])?;
 

--- a/src/pdata/space_map_common.rs
+++ b/src/pdata/space_map_common.rs
@@ -250,6 +250,90 @@ pub fn write_common(w: &mut WriteBatcher, sm: &dyn SpaceMap) -> Result<(Vec<Inde
     Ok((index_entries, ref_count_root))
 }
 
+pub fn write_metadata_common(w: &mut WriteBatcher) -> Result<(Vec<IndexEntry>, u64)> {
+    use BitmapEntry::*;
+
+    let mut index_entries = Vec::new();
+    let mut overflow_builder: BTreeBuilder<u32> = BTreeBuilder::new(Box::new(NoopRC {}));
+
+    // how many bitmaps do we need?
+    let nr_blocks = w.sm.lock().unwrap().get_nr_blocks()?;
+    let nr_bitmaps = div_up(nr_blocks, ENTRIES_PER_BITMAP as u64) as usize;
+
+    // how many blocks are allocated or reserved so far?
+    let reserved = w.get_reserved_range();
+    if reserved.end < reserved.start {
+        return Err(anyhow!("unsupported allocation pattern"));
+    }
+    let nr_used_bitmaps = div_up(reserved.end, ENTRIES_PER_BITMAP as u64) as usize;
+
+    for bm in 0..nr_used_bitmaps {
+        let begin = bm as u64 * ENTRIES_PER_BITMAP as u64;
+        let len = std::cmp::min(nr_blocks - begin, ENTRIES_PER_BITMAP as u64);
+        let mut entries = Vec::with_capacity(ENTRIES_PER_BITMAP);
+        let mut first_free: Option<u32> = None;
+
+        // blocks beyond the limit won't be checked right now, thus are marked as freed
+        let limit = std::cmp::min(reserved.end - begin, ENTRIES_PER_BITMAP as u64);
+        let mut nr_free: u32 = (len - limit) as u32;
+
+        for i in 0..limit {
+            let b = begin + i;
+            let rc = w.sm.lock().unwrap().get(b)?;
+            let e = match rc {
+                0 => {
+                    nr_free += 1;
+                    if first_free.is_none() {
+                        first_free = Some(i as u32);
+                    }
+                    Small(0)
+                }
+                1 => Small(1),
+                2 => Small(2),
+                _ => {
+                    overflow_builder.push_value(w, b as u64, rc)?;
+                    Overflow
+                }
+            };
+            entries.push(e);
+        }
+
+        // Fill unused entries with zeros
+        if limit < len {
+            entries.resize_with(len as usize, || BitmapEntry::Small(0));
+        }
+
+        let blocknr = write_bitmap(w, entries)?;
+
+        // Insert into the index list
+        let ie = IndexEntry {
+            blocknr,
+            nr_free,
+            none_free_before: first_free.unwrap_or(limit as u32),
+        };
+        index_entries.push(ie);
+    }
+
+    // Fill the rest of the bitmaps with zeros
+    for bm in nr_used_bitmaps..nr_bitmaps {
+        let begin = bm as u64 * ENTRIES_PER_BITMAP as u64;
+        let len = std::cmp::min(nr_blocks - begin, ENTRIES_PER_BITMAP as u64);
+        let entries = vec![BitmapEntry::Small(0); ENTRIES_PER_BITMAP];
+        let blocknr = write_bitmap(w, entries)?;
+
+        // Insert into the index list
+        let ie = IndexEntry {
+            blocknr,
+            nr_free: len as u32,
+            none_free_before: 0,
+        };
+        index_entries.push(ie);
+    }
+
+    let ref_count_root = overflow_builder.complete(w)?;
+    Ok((index_entries, ref_count_root))
+}
+
 fn write_bitmap(w: &mut WriteBatcher, entries: Vec<BitmapEntry>) -> Result<u64> {
     // allocate a new block
     let b = w.alloc_zeroed()?;

--- a/src/pdata/space_map_common.rs
+++ b/src/pdata/space_map_common.rs
@@ -200,7 +200,7 @@ pub fn write_common(w: &mut WriteBatcher, sm: &dyn SpaceMap) -> Result<(Vec<Inde
     use BitmapEntry::*;
 
     let mut index_entries = Vec::new();
-    let mut overflow_builder: Builder<u32> = Builder::new(Box::new(NoopRC {}));
+    let mut overflow_builder: BTreeBuilder<u32> = BTreeBuilder::new(Box::new(NoopRC {}));
 
     // how many bitmaps do we need?
     for bm in 0..div_up(sm.get_nr_blocks()? as usize, ENTRIES_PER_BITMAP) {

--- a/src/pdata/space_map_common.rs
+++ b/src/pdata/space_map_common.rs
@@ -111,8 +111,8 @@ impl Pack for Bitmap {
     fn pack<W: WriteBytesExt>(&self, out: &mut W) -> Result<()> {
         use BitmapEntry::*;
 
-        out.write_u32::<LittleEndian>(0)?;
-        out.write_u32::<LittleEndian>(0)?;
+        out.write_u32::<LittleEndian>(0)?; // csum
+        out.write_u32::<LittleEndian>(0)?; // padding
         out.write_u64::<LittleEndian>(self.blocknr)?;
 
         for chunk in self.entries.chunks(32) {
@@ -135,6 +135,7 @@ impl Pack for Bitmap {
                     }
                 }
             }
+            w >>= 64 - chunk.len() * 2;
 
             u64::pack(&w, out)?;
         }
@@ -203,15 +204,18 @@ pub fn write_common(w: &mut WriteBatcher, sm: &dyn SpaceMap) -> Result<(Vec<Inde
     let mut overflow_builder: BTreeBuilder<u32> = BTreeBuilder::new(Box::new(NoopRC {}));
 
     // how many bitmaps do we need?
-    for bm in 0..div_up(sm.get_nr_blocks()? as usize, ENTRIES_PER_BITMAP) {
+    let nr_blocks = sm.get_nr_blocks()?;
+    let nr_bitmaps = div_up(nr_blocks, ENTRIES_PER_BITMAP as u64) as usize;
+
+    for bm in 0..nr_bitmaps {
+        let begin = bm as u64 * ENTRIES_PER_BITMAP as u64;
+        let len = std::cmp::min(nr_blocks - begin, ENTRIES_PER_BITMAP as u64);
         let mut entries = Vec::with_capacity(ENTRIES_PER_BITMAP);
         let mut first_free: Option<u32> = None;
         let mut nr_free: u32 = 0;
-        for i in 0..ENTRIES_PER_BITMAP {
-            let b: u64 = ((bm * ENTRIES_PER_BITMAP) as u64) + i as u64;
-            if b >= sm.get_nr_blocks()? {
-                break;
-            }
+
+        for i in 0..len {
+            let b = begin + i;
             let rc = sm.get(b)?;
             let e = match rc {
                 0 => {
@@ -231,27 +235,33 @@ pub fn write_common(w: &mut WriteBatcher, sm: &dyn SpaceMap) -> Result<(Vec<Inde
             entries.push(e);
         }
 
-        // allocate a new block
-        let b = w.alloc()?;
-        let mut cursor = Cursor::new(b.get_data());
+        let blocknr = write_bitmap(w, entries)?;
 
-        // write the bitmap to it
-        let blocknr = b.loc;
-        let bitmap = Bitmap { blocknr, entries };
-        bitmap.pack(&mut cursor)?;
-        w.write(b, checksum::BT::BITMAP)?;
-
-        // Insert into the index tree
+        // Insert into the index list
         let ie = IndexEntry {
             blocknr,
             nr_free,
-            none_free_before: first_free.unwrap_or(ENTRIES_PER_BITMAP as u32),
+            none_free_before: first_free.unwrap_or(len as u32),
         };
         index_entries.push(ie);
     }
 
     let ref_count_root = overflow_builder.complete(w)?;
     Ok((index_entries, ref_count_root))
+}
+
+fn write_bitmap(w: &mut WriteBatcher, entries: Vec<BitmapEntry>) -> Result<u64> {
+    // allocate a new block
+    let b = w.alloc_zeroed()?;
+    let mut cursor = Cursor::new(b.get_data());
+
+    // write the bitmap to it
+    let blocknr = b.loc;
+    let bitmap = Bitmap { blocknr, entries };
+    bitmap.pack(&mut cursor)?;
+    w.write(b, checksum::BT::BITMAP)?;
+
+    Ok(blocknr)
 }
 
 //------------------------------------------

--- a/src/pdata/space_map_disk.rs
+++ b/src/pdata/space_map_disk.rs
@@ -10,7 +10,7 @@ use crate::write_batcher::*;
 pub fn write_disk_sm(w: &mut WriteBatcher, sm: &dyn SpaceMap) -> Result<SMRoot> {
     let (index_entries, ref_count_root) = write_common(w, sm)?;
 
-    let mut index_builder: Builder<IndexEntry> = Builder::new(Box::new(NoopRC {}));
+    let mut index_builder: BTreeBuilder<IndexEntry> = BTreeBuilder::new(Box::new(NoopRC {}));
     for (i, ie) in index_entries.iter().enumerate() {
         index_builder.push_value(w, i as u64, *ie)?;
     }

--- a/src/pdata/space_map_metadata.rs
+++ b/src/pdata/space_map_metadata.rs
@@ -70,7 +70,7 @@ fn adjust_counts(w: &mut WriteBatcher, ie: &IndexEntry, allocs: &[u64]) -> Resul
     use BitmapEntry::*;
 
     let mut first_free = ie.none_free_before;
-    let mut nr_free = ie.nr_free - allocs.len() as u32;
+    let nr_free = ie.nr_free - allocs.len() as u32;
 
     // Read the bitmap
     let bitmap_block = w.engine.read(ie.blocknr)?;
@@ -80,10 +80,6 @@ fn adjust_counts(w: &mut WriteBatcher, ie: &IndexEntry, allocs: &[u64]) -> Resul
     for a in allocs {
         if first_free == *a as u32 {
             first_free = *a as u32 + 1;
-        }
-
-        if bitmap.entries[*a as usize] == Small(0) {
-            nr_free -= 1;
         }
 
         bitmap.entries[*a as usize] = Small(1);

--- a/src/thin/restore.rs
+++ b/src/thin/restore.rs
@@ -251,8 +251,7 @@ fn build_data_sm(w: &mut WriteBatcher, sm: &dyn SpaceMap) -> Result<Vec<u8>> {
 fn build_metadata_sm(w: &mut WriteBatcher) -> Result<Vec<u8>> {
     let mut sm_root = vec![0u8; SPACE_MAP_ROOT_SIZE];
     let mut cur = Cursor::new(&mut sm_root);
-    let sm_without_meta = clone_space_map(w.sm.lock().unwrap().deref())?;
-    let r = write_metadata_sm(w, sm_without_meta.deref())?;
+    let r = write_metadata_sm(w)?;
     r.pack(&mut cur)?;
 
     Ok(sm_root)

--- a/src/thin/restore.rs
+++ b/src/thin/restore.rs
@@ -330,7 +330,6 @@ pub fn restore(opts: ThinRestoreOptions) -> Result<()> {
     // Build data space map
     let data_sm_root = build_data_sm(&mut w, pass.data_sm.lock().unwrap().deref())?;
 
-    // FIXME: I think we need to decrement the shared leaves
     // Build metadata space map
     let metadata_sm_root = build_metadata_sm(&mut w)?;
 

--- a/src/thin/restore.rs
+++ b/src/thin/restore.rs
@@ -303,7 +303,7 @@ pub fn restore(opts: ThinRestoreOptions) -> Result<()> {
     let pass = pass.get_result()?;
 
     // Build the device details tree.
-    let mut details_builder: Builder<DeviceDetail> = Builder::new(Box::new(NoopRC {}));
+    let mut details_builder: BTreeBuilder<DeviceDetail> = BTreeBuilder::new(Box::new(NoopRC {}));
     for (thin_id, (detail, _)) in &pass.devices {
         details_builder.push_value(&mut w, *thin_id as u64, *detail)?;
     }
@@ -314,14 +314,14 @@ pub fn restore(opts: ThinRestoreOptions) -> Result<()> {
     for (thin_id, (_, nodes)) in &pass.devices {
         ctx.report
             .info(&format!("building btree for device {}", thin_id));
-        let mut builder: Builder<BlockTime> = Builder::new(Box::new(NoopRC {}));
+        let mut builder: BTreeBuilder<BlockTime> = BTreeBuilder::new(Box::new(NoopRC {}));
         builder.push_leaves(&mut w, nodes)?;
         let root = builder.complete(&mut w)?;
         devs.insert(*thin_id, root);
     }
 
     // Build the top level mapping tree
-    let mut builder: Builder<u64> = Builder::new(Box::new(NoopRC {}));
+    let mut builder: BTreeBuilder<u64> = BTreeBuilder::new(Box::new(NoopRC {}));
     for (thin_id, root) in devs {
         builder.push_value(&mut w, thin_id as u64, root)?;
     }

--- a/src/write_batcher.rs
+++ b/src/write_batcher.rs
@@ -114,6 +114,13 @@ impl WriteBatcher {
         tmp
     }
 
+    pub fn get_reserved_range(&self) -> std::ops::Range<u64> {
+        std::ops::Range {
+            start: self.reserved.start,
+            end: self.reserved.end,
+        }
+    }
+
     pub fn write(&mut self, b: Block, kind: checksum::BT) -> Result<()> {
         checksum::write_checksum(&mut b.get_data(), kind)?;
 

--- a/src/write_batcher.rs
+++ b/src/write_batcher.rs
@@ -47,6 +47,18 @@ impl WriteBatcher {
         Ok(Block::new(b.unwrap()))
     }
 
+    pub fn alloc_zeroed(&mut self) -> Result<Block> {
+        let mut sm = self.sm.lock().unwrap();
+        let b = sm.alloc()?;
+
+        if b.is_none() {
+            return Err(anyhow!("out of metadata space"));
+        }
+
+        self.allocations.insert(b.unwrap());
+        Ok(Block::zeroed(b.unwrap()))
+    }
+
     pub fn clear_allocations(&mut self) -> BTreeSet<u64> {
         let mut tmp = BTreeSet::new();
         std::mem::swap(&mut tmp, &mut self.allocations);

--- a/src/write_batcher.rs
+++ b/src/write_batcher.rs
@@ -1,5 +1,6 @@
 use anyhow::{anyhow, Result};
 use std::collections::BTreeSet;
+use std::ops::DerefMut;
 use std::sync::{Arc, Mutex};
 
 use crate::checksum;
@@ -17,7 +18,33 @@ pub struct WriteBatcher {
 
     batch_size: usize,
     queue: Vec<Block>,
+
+    // The actual blocks allocated or reserved by this WriteBatcher
     allocations: BTreeSet<u64>,
+
+    // The reserved range covers all the blocks allocated or reserved by this
+    // WriteBatcher, and the blocks already occupied. No blocks in this range
+    // are expected to be freed, hence a single range is used for the representation.
+    reserved: std::ops::Range<u64>,
+}
+
+pub fn find_free(sm: &mut dyn SpaceMap, reserved: &std::ops::Range<u64>) -> Result<u64> {
+    let nr_blocks = sm.get_nr_blocks()?;
+    let mut b;
+    if reserved.end >= reserved.start {
+        b = sm.find_free(reserved.end, nr_blocks)?;
+        if b.is_none() {
+            b = sm.find_free(0, reserved.start)?;
+        }
+    } else {
+        b = sm.find_free(reserved.end, reserved.start)?;
+    }
+
+    if b.is_none() {
+        return Err(anyhow!("out of metadata space"));
+    }
+
+    Ok(b.unwrap())
 }
 
 impl WriteBatcher {
@@ -26,37 +53,59 @@ impl WriteBatcher {
         sm: Arc<Mutex<dyn SpaceMap>>,
         batch_size: usize,
     ) -> WriteBatcher {
+        let alloc_begin = sm.lock().unwrap().get_alloc_begin().unwrap_or(0);
+
         WriteBatcher {
             engine,
             sm,
             batch_size,
             queue: Vec::with_capacity(batch_size),
             allocations: BTreeSet::new(),
+            reserved: std::ops::Range {
+                start: alloc_begin,
+                end: alloc_begin,
+            },
         }
     }
 
     pub fn alloc(&mut self) -> Result<Block> {
         let mut sm = self.sm.lock().unwrap();
-        let b = sm.alloc()?;
+        let b = find_free(sm.deref_mut(), &self.reserved)?;
+        self.reserved.end = b + 1;
+        self.allocations.insert(b);
 
-        if b.is_none() {
-            return Err(anyhow!("out of metadata space"));
-        }
+        sm.set(b, 1)?;
 
-        self.allocations.insert(b.unwrap());
-        Ok(Block::new(b.unwrap()))
+        Ok(Block::new(b))
     }
 
     pub fn alloc_zeroed(&mut self) -> Result<Block> {
         let mut sm = self.sm.lock().unwrap();
-        let b = sm.alloc()?;
+        let b = find_free(sm.deref_mut(), &self.reserved)?;
+        self.reserved.end = b + 1;
+        self.allocations.insert(b);
 
-        if b.is_none() {
-            return Err(anyhow!("out of metadata space"));
-        }
+        sm.set(b, 1)?;
 
-        self.allocations.insert(b.unwrap());
-        Ok(Block::zeroed(b.unwrap()))
+        Ok(Block::zeroed(b))
+    }
+
+    pub fn reserve(&mut self) -> Result<Block> {
+        let mut sm = self.sm.lock().unwrap();
+        let b = find_free(sm.deref_mut(), &self.reserved)?;
+        self.reserved.end = b + 1;
+        self.allocations.insert(b);
+
+        Ok(Block::new(b))
+    }
+
+    pub fn reserve_zeroed(&mut self) -> Result<Block> {
+        let mut sm = self.sm.lock().unwrap();
+        let b = find_free(sm.deref_mut(), &self.reserved)?;
+        self.reserved.end = b + 1;
+        self.allocations.insert(b);
+
+        Ok(Block::zeroed(b))
     }
 
     pub fn clear_allocations(&mut self) -> BTreeSet<u64> {

--- a/tests/cache_check.rs
+++ b/tests/cache_check.rs
@@ -42,7 +42,7 @@ fn accepts_help() -> Result<()> {
 #[test]
 fn missing_metadata() -> Result<()> {
     let stderr = run_fail(cache_check!())?;
-    assert!(stderr.contains("No input file provided"));
+    assert!(stderr.contains(msg::MISSING_INPUT_ARG));
     Ok(())
 }
 
@@ -66,7 +66,7 @@ fn unreadable_metadata() -> Result<()> {
     let md = mk_valid_md(&mut td)?;
     cmd!("chmod", "-r", &md).run()?;
     let stderr = run_fail(cache_check!(&md))?;
-    assert!(stderr.contains("syscall 'open' failed: Permission denied"));
+    assert!(stderr.contains("Permission denied"));
     Ok(())
 }
 

--- a/tests/cache_check.rs
+++ b/tests/cache_check.rs
@@ -12,14 +12,14 @@ use common::*;
 #[test]
 fn accepts_v() -> Result<()> {
     let stdout = cache_check!("-V").read()?;
-    assert_eq!(stdout, tools_version());
+    assert!(stdout.contains(tools_version()));
     Ok(())
 }
 
 #[test]
 fn accepts_version() -> Result<()> {
     let stdout = cache_check!("--version").read()?;
-    assert_eq!(stdout, tools_version());
+    assert!(stdout.contains(tools_version()));
     Ok(())
 }
 

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -18,6 +18,22 @@ use test_dir::TestDir;
 
 //------------------------------------------
 
+#[cfg(not(feature = "rust_tests"))]
+pub mod msg {
+    pub const FILE_NOT_FOUND: &str = "Couldn't stat file";
+    pub const MISSING_INPUT_ARG: &str = "No input file provided";
+    pub const MISSING_OUTPUT_ARG: &str = "No output file provided";
+}
+
+#[cfg(feature = "rust_tests")]
+pub mod msg {
+    pub const FILE_NOT_FOUND: &str = "Couldn't find input file";
+    pub const MISSING_INPUT_ARG: &str = "The following required arguments were not provided";
+    pub const MISSING_OUTPUT_ARG: &str = "The following required arguments were not provided";
+}
+
+//------------------------------------------
+
 #[macro_export]
 macro_rules! path_to_cpp {
     ($name: literal) => {

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -18,14 +18,46 @@ use test_dir::TestDir;
 
 //------------------------------------------
 
+#[macro_export]
+macro_rules! path_to_cpp {
+    ($name: literal) => {
+        concat!("bin/", $name)
+    };
+}
+
+#[macro_export]
+macro_rules! path_to_rust {
+    ($name: literal) => {
+        env!(concat!("CARGO_BIN_EXE_", $name))
+    };
+}
+
+#[cfg(not(feature = "rust_tests"))]
+#[macro_export]
+macro_rules! path_to {
+    ($name: literal) => {
+        path_to_cpp!($name)
+    };
+}
+
+#[cfg(feature = "rust_tests")]
+#[macro_export]
+macro_rules! path_to {
+    ($name: literal) => {
+        path_to_rust!($name)
+    };
+}
+
 // FIXME: write a macro to generate these commands
+// Known issue of nested macro definition: https://github.com/rust-lang/rust/issues/35853
+// RFC: https://github.com/rust-lang/rfcs/blob/master/text/3086-macro-metavar-expr.md
 #[macro_export]
 macro_rules! thin_check {
     ( $( $arg: expr ),* ) => {
         {
             use std::ffi::OsString;
             let args: &[OsString] = &[$( Into::<OsString>::into($arg) ),*];
-            duct::cmd("bin/thin_check", args).stdout_capture().stderr_capture()
+            duct::cmd(path_to!("thin_check"), args).stdout_capture().stderr_capture()
         }
     };
 }
@@ -36,7 +68,7 @@ macro_rules! thin_restore {
         {
             use std::ffi::OsString;
             let args: &[OsString] = &[$( Into::<OsString>::into($arg) ),*];
-            duct::cmd("bin/thin_restore", args).stdout_capture().stderr_capture()
+            duct::cmd(path_to!("thin_restore"), args).stdout_capture().stderr_capture()
         }
     };
 }
@@ -47,7 +79,7 @@ macro_rules! thin_dump {
         {
             use std::ffi::OsString;
             let args: &[OsString] = &[$( Into::<OsString>::into($arg) ),*];
-            duct::cmd("bin/thin_dump", args).stdout_capture().stderr_capture()
+            duct::cmd(path_to!("thin_dump"), args).stdout_capture().stderr_capture()
         }
     };
 }
@@ -58,7 +90,7 @@ macro_rules! thin_rmap {
         {
             use std::ffi::OsString;
             let args: &[OsString] = &[$( Into::<OsString>::into($arg) ),*];
-            duct::cmd("bin/thin_rmap", args).stdout_capture().stderr_capture()
+            duct::cmd(path_to_cpp!("thin_rmap"), args).stdout_capture().stderr_capture()
         }
     };
 }
@@ -69,7 +101,7 @@ macro_rules! thin_repair {
         {
             use std::ffi::OsString;
             let args: &[OsString] = &[$( Into::<OsString>::into($arg) ),*];
-            duct::cmd("bin/thin_repair", args).stdout_capture().stderr_capture()
+            duct::cmd(path_to_cpp!("thin_repair"), args).stdout_capture().stderr_capture()
         }
     };
 }
@@ -80,7 +112,7 @@ macro_rules! thin_delta {
         {
             use std::ffi::OsString;
             let args: &[OsString] = &[$( Into::<OsString>::into($arg) ),*];
-            duct::cmd("bin/thin_delta", args).stdout_capture().stderr_capture()
+            duct::cmd(path_to_cpp!("thin_delta"), args).stdout_capture().stderr_capture()
         }
     };
 }
@@ -91,7 +123,7 @@ macro_rules! thin_metadata_pack {
         {
             use std::ffi::OsString;
             let args: &[OsString] = &[$( Into::<OsString>::into($arg) ),*];
-            duct::cmd("bin/thin_metadata_pack", args).stdout_capture().stderr_capture()
+            duct::cmd(path_to_rust!("thin_metadata_pack"), args).stdout_capture().stderr_capture()
         }
     };
 }
@@ -102,7 +134,7 @@ macro_rules! thin_metadata_unpack {
         {
             use std::ffi::OsString;
             let args: &[OsString] = &[$( Into::<OsString>::into($arg) ),*];
-            duct::cmd("bin/thin_metadata_unpack", args).stdout_capture().stderr_capture()
+            duct::cmd(path_to_rust!("thin_metadata_unpack"), args).stdout_capture().stderr_capture()
         }
     };
 }
@@ -113,7 +145,7 @@ macro_rules! cache_check {
         {
             use std::ffi::OsString;
             let args: &[OsString] = &[$( Into::<OsString>::into($arg) ),*];
-            duct::cmd("bin/cache_check", args).stdout_capture().stderr_capture()
+            duct::cmd(path_to!("cache_check"), args).stdout_capture().stderr_capture()
         }
     };
 }
@@ -124,7 +156,7 @@ macro_rules! thin_generate_metadata {
         {
             use std::ffi::OsString;
             let args: &[OsString] = &[$( Into::<OsString>::into($arg) ),*];
-            duct::cmd("bin/thin_generate_metadata", args).stdout_capture().stderr_capture()
+            duct::cmd(path_to_cpp!("thin_generate_metadata"), args).stdout_capture().stderr_capture()
         }
     };
 }
@@ -135,7 +167,7 @@ macro_rules! thin_generate_mappings {
         {
             use std::ffi::OsString;
             let args: &[OsString] = &[$( Into::<OsString>::into($arg) ),*];
-            duct::cmd("bin/thin_generate_mappings", args).stdout_capture().stderr_capture()
+            duct::cmd(path_to_cpp!("thin_generate_mappings"), args).stdout_capture().stderr_capture()
         }
     };
 }

--- a/tests/thin_check.rs
+++ b/tests/thin_check.rs
@@ -13,14 +13,14 @@ use common::*;
 #[test]
 fn accepts_v() -> Result<()> {
     let stdout = thin_check!("-V").read()?;
-    assert_eq!(stdout, tools_version());
+    assert!(stdout.contains(tools_version()));
     Ok(())
 }
 
 #[test]
 fn accepts_version() -> Result<()> {
     let stdout = thin_check!("--version").read()?;
-    assert_eq!(stdout, tools_version());
+    assert!(stdout.contains(tools_version()));
     Ok(())
 }
 

--- a/tests/thin_delta.rs
+++ b/tests/thin_delta.rs
@@ -10,14 +10,14 @@ use common::*;
 #[test]
 fn accepts_v() -> Result<()> {
     let stdout = thin_delta!("-V").read()?;
-    assert_eq!(stdout, tools_version());
+    assert!(stdout.contains(tools_version()));
     Ok(())
 }
 
 #[test]
 fn accepts_version() -> Result<()> {
     let stdout = thin_delta!("--version").read()?;
-    assert_eq!(stdout, tools_version());
+    assert!(stdout.contains(tools_version()));
     Ok(())
 }
 

--- a/tests/thin_delta.rs
+++ b/tests/thin_delta.rs
@@ -65,6 +65,7 @@ fn snap2_unspecified() -> Result<()> {
 #[test]
 fn dev_unspecified() -> Result<()> {
     let stderr = run_fail(thin_delta!("--snap1", "45", "--snap2", "46"))?;
-    assert!(stderr.contains("No input device provided"));
+    // TODO: replace with msg::MISSING_INPUT_ARG once the rust version is ready
+    assert!(stderr.contains("No input file provided"));
     Ok(())
 }

--- a/tests/thin_repair.rs
+++ b/tests/thin_repair.rs
@@ -11,14 +11,14 @@ use common::*;
 #[test]
 fn accepts_v() -> Result<()> {
     let stdout = thin_repair!("-V").read()?;
-    assert_eq!(stdout, tools_version());
+    assert!(stdout.contains(tools_version()));
     Ok(())
 }
 
 #[test]
 fn accepts_version() -> Result<()> {
     let stdout = thin_repair!("--version").read()?;
-    assert_eq!(stdout, tools_version());
+    assert!(stdout.contains(tools_version()));
     Ok(())
 }
 

--- a/tests/thin_repair.rs
+++ b/tests/thin_repair.rs
@@ -53,6 +53,7 @@ fn missing_input_file() -> Result<()> {
     let md = mk_zeroed_md(&mut td)?;
     let stderr = run_fail(thin_repair!("-i", "no-such-file", "-o", &md))?;
     assert!(superblock_all_zeroes(&md)?);
+    // TODO: replace with msg::FILE_NOT_FOUND once the rust version is ready
     assert!(stderr.contains("Couldn't stat file"));
     Ok(())
 }
@@ -72,6 +73,7 @@ fn missing_output_file() -> Result<()> {
     let mut td = TestDir::new()?;
     let md = mk_valid_md(&mut td)?;
     let stderr = run_fail(thin_repair!("-i", &md))?;
+    // TODO: replace with msg::MISSING_OUTPUT_ARG once the rust version is ready
     assert!(stderr.contains("No output file provided."));
     Ok(())
 }

--- a/tests/thin_restore.rs
+++ b/tests/thin_restore.rs
@@ -44,7 +44,7 @@ fn no_input_file() -> Result<()> {
     let mut td = TestDir::new()?;
     let md = mk_zeroed_md(&mut td)?;
     let stderr = run_fail(thin_restore!("-o", &md))?;
-    assert!(stderr.contains("No input file provided."));
+    assert!(stderr.contains(msg::MISSING_INPUT_ARG));
     Ok(())
 }
 
@@ -54,7 +54,7 @@ fn missing_input_file() -> Result<()> {
     let md = mk_zeroed_md(&mut td)?;
     let stderr = run_fail(thin_restore!("-i", "no-such-file", "-o", &md))?;
     assert!(superblock_all_zeroes(&md)?);
-    assert!(stderr.contains("Couldn't stat file"));
+    assert!(stderr.contains(msg::FILE_NOT_FOUND));
     Ok(())
 }
 
@@ -73,7 +73,7 @@ fn no_output_file() -> Result<()> {
     let mut td = TestDir::new()?;
     let xml = mk_valid_xml(&mut td)?;
     let stderr = run_fail(thin_restore!("-i", &xml))?;
-    assert!(stderr.contains("No output file provided."));
+    assert!(stderr.contains(msg::MISSING_OUTPUT_ARG));
     Ok(())
 }
 

--- a/tests/thin_restore.rs
+++ b/tests/thin_restore.rs
@@ -12,14 +12,14 @@ use common::*;
 #[test]
 fn accepts_v() -> Result<()> {
     let stdout = thin_restore!("-V").read()?;
-    assert_eq!(stdout, tools_version());
+    assert!(stdout.contains(tools_version()));
     Ok(())
 }
 
 #[test]
 fn accepts_version() -> Result<()> {
     let stdout = thin_restore!("--version").read()?;
-    assert_eq!(stdout, tools_version());
+    assert!(stdout.contains(tools_version()));
     Ok(())
 }
 

--- a/tests/thin_rmap.rs
+++ b/tests/thin_rmap.rs
@@ -10,14 +10,14 @@ use common::*;
 #[test]
 fn accepts_v() -> Result<()> {
     let stdout = thin_rmap!("-V").read()?;
-    assert_eq!(stdout, tools_version());
+    assert!(stdout.contains(tools_version()));
     Ok(())
 }
 
 #[test]
 fn accepts_version() -> Result<()> {
     let stdout = thin_rmap!("--version").read()?;
-    assert_eq!(stdout, tools_version());
+    assert!(stdout.contains(tools_version()));
     Ok(())
 }
 

--- a/thin-provisioning/thin_delta.cc
+++ b/thin-provisioning/thin_delta.cc
@@ -687,7 +687,7 @@ thin_delta_cmd::run(int argc, char **argv)
 	}
 
 	if (argc == optind)
-		die("No input device provided.");
+		die("No input file provided.");
 	else
 		fs.dev = argv[optind];
 


### PR DESCRIPTION
- Fix errors in restored metadata
  * Fix reference counts of btree nodes
  * Fix overflowed index_entry::none_free_before
  * Fix index_entry::nr_free in metadata space map
  * Allow packing unaligned number of bitmap entries (unaligned to 32 entries) for fast initialization
- Improve performance a little
  * Build metadata space map in-place (No extra space map or block set is required)
  * Do not copy & iterate btree leaves twice while building thin mapping trees
  * Remove unnecessary data copying in array construction
- Enable testing the Rust targets