### PR TITLE
[build] Remove -lboost_iostreams linker flag

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -190,7 +190,7 @@ CXXFLAGS+=@CXX_STRERROR_FLAG@
 CXXFLAGS+=@LFS_FLAGS@
 CPPFLAGS?=@CPPFLAGS@
 CPPFLAGS+=-I$(TOP_BUILDDIR) -I$(TOP_DIR)
-LIBS:=-laio -lexpat -lboost_iostreams -ldl
+LIBS:=-laio -lexpat -ldl
 DEV_LIBS:=-lncurses
 
 ifeq ("@STATIC_CXX@", "yes")


### PR DESCRIPTION
This was previously needed for `thin-provisioning/thin_metadata_pack.cc`
but that file was rewritten in Rust and no longer needs Boost. The flag
causes every binary to have a completely redundant depedency on
libboost_iostream.so, which is an [issue](https://bugzilla.redhat.com/show_bug.cgi?id=1974781) for RHEL packaging.

The flag was added in 0e1700fbe9e34c58f1019a0c425fad9e62db24a3 and made redundant by 61de3f92873310d8a25a8392f7e53ef67cc3d88c.

I've only tested that everything still builds with this change.