### PR TITLE
First pass at thin_repair and cache_repair

### DIFF
--- a/src/bin/cache_repair.rs
+++ b/src/bin/cache_repair.rs
@@ -1,0 +1,79 @@
+extern crate clap;
+extern crate thinp;
+
+use atty::Stream;
+use clap::{App, Arg};
+use std::path::Path;
+use std::process;
+use std::process::exit;
+use std::sync::Arc;
+use thinp::cache::repair::{repair, CacheRepairOptions};
+use thinp::file_utils;
+use thinp::report::*;
+
+fn main() {
+    let parser = App::new("cache_repair")
+        .version(thinp::version::tools_version())
+        .about("Repair binary cache metadata, and write it to a different device or file")
+        // flags
+        .arg(
+            Arg::with_name("ASYNC_IO")
+                .help("Force use of io_uring for synchronous io")
+                .long("async-io")
+                .hidden(true),
+        )
+        .arg(
+            Arg::with_name("QUIET")
+                .help("Suppress output messages, return only exit code.")
+                .short("q")
+                .long("quiet"),
+        )
+        // options
+        .arg(
+            Arg::with_name("INPUT")
+                .help("Specify the input device")
+                .short("i")
+                .long("input")
+                .value_name("INPUT")
+                .required(true),
+        )
+        .arg(
+            Arg::with_name("OUTPUT")
+                .help("Specify the output device")
+                .short("o")
+                .long("output")
+                .value_name("OUTPUT")
+                .required(true),
+        );
+
+    let matches = parser.get_matches();
+    let input_file = Path::new(matches.value_of("INPUT").unwrap());
+    let output_file = Path::new(matches.value_of("OUTPUT").unwrap());
+
+    if !file_utils::file_exists(input_file) {
+        eprintln!("Couldn't find input file '{:?}'.", &input_file);
+        exit(1);
+    }
+
+    let report;
+
+    if matches.is_present("QUIET") {
+        report = std::sync::Arc::new(mk_quiet_report());
+    } else if atty::is(Stream::Stdout) {
+        report = std::sync::Arc::new(mk_progress_bar_report());
+    } else {
+        report = Arc::new(mk_simple_report());
+    }
+
+    let opts = CacheRepairOptions {
+        input: &input_file,
+        output: &output_file,
+        async_io: matches.is_present("ASYNC_IO"),
+        report,
+    };
+
+    if let Err(reason) = repair(opts) {
+        eprintln!("{}", reason);
+        process::exit(1);
+    }
+}

--- a/src/bin/cache_restore.rs
+++ b/src/bin/cache_restore.rs
@@ -29,6 +29,12 @@ fn main() {
                 .value_name("OVERRIDE_MAPPING_ROOT")
                 .takes_value(true),
         )
+        .arg(
+            Arg::with_name("QUIET")
+                .help("Suppress output messages, return only exit code.")
+                .short("q")
+                .long("quiet"),
+        )
         // options
         .arg(
             Arg::with_name("INPUT")

--- a/src/bin/thin_repair.rs
+++ b/src/bin/thin_repair.rs
@@ -1,0 +1,86 @@
+extern crate clap;
+extern crate thinp;
+
+use atty::Stream;
+use clap::{App, Arg};
+use std::path::Path;
+use std::process;
+use std::process::exit;
+use std::sync::Arc;
+use thinp::file_utils;
+use thinp::report::*;
+use thinp::thin::repair::{repair, ThinRepairOptions};
+
+fn main() {
+    let parser = App::new("thin_repair")
+        .version(thinp::version::tools_version())
+        .about("Repair thin-provisioning metadata, and write it to different device or file")
+        // flags
+        .arg(
+            Arg::with_name("ASYNC_IO")
+                .help("Force use of io_uring for synchronous io")
+                .long("async-io")
+                .hidden(true),
+        )
+        .arg(
+            Arg::with_name("QUIET")
+                .help("Suppress output messages, return only exit code.")
+                .short("q")
+                .long("quiet"),
+        )
+        // options
+        .arg(
+            Arg::with_name("INPUT")
+                .help("Specify the input device")
+                .short("i")
+                .long("input")
+                .value_name("INPUT")
+                .required(true),
+        )
+        .arg(
+            Arg::with_name("OUTPUT")
+                .help("Specify the output device")
+                .short("o")
+                .long("output")
+                .value_name("OUTPUT")
+                .required(true),
+        )
+        .arg(
+            Arg::with_name("OVERRIDE_MAPPING_ROOT")
+                .help("Specify a mapping root to use")
+                .long("override-mapping-root")
+                .value_name("OVERRIDE_MAPPING_ROOT")
+                .takes_value(true),
+        );
+
+    let matches = parser.get_matches();
+    let input_file = Path::new(matches.value_of("INPUT").unwrap());
+    let output_file = Path::new(matches.value_of("OUTPUT").unwrap());
+
+    if !file_utils::file_exists(input_file) {
+        eprintln!("Couldn't find input file '{:?}'.", &input_file);
+        exit(1);
+    }
+
+    let report;
+
+    if matches.is_present("QUIET") {
+        report = std::sync::Arc::new(mk_quiet_report());
+    } else if atty::is(Stream::Stdout) {
+        report = std::sync::Arc::new(mk_progress_bar_report());
+    } else {
+        report = Arc::new(mk_simple_report());
+    }
+
+    let opts = ThinRepairOptions {
+        input: &input_file,
+        output: &output_file,
+        async_io: matches.is_present("ASYNC_IO"),
+        report,
+    };
+
+    if let Err(reason) = repair(opts) {
+        eprintln!("{}", reason);
+        process::exit(1);
+    }
+}

--- a/src/bin/thin_restore.rs
+++ b/src/bin/thin_restore.rs
@@ -22,6 +22,12 @@ fn main() {
                 .long("async-io")
                 .hidden(true),
         )
+        .arg(
+            Arg::with_name("QUIET")
+                .help("Suppress output messages, return only exit code.")
+                .short("q")
+                .long("quiet"),
+        )
         // options
         .arg(
             Arg::with_name("INPUT")
@@ -33,7 +39,7 @@ fn main() {
         )
         .arg(
             Arg::with_name("OUTPUT")
-                .help("Specify the output device to check")
+                .help("Specify the output device")
                 .short("o")
                 .long("output")
                 .value_name("OUTPUT")

--- a/src/cache/dump.rs
+++ b/src/cache/dump.rs
@@ -7,9 +7,10 @@ use std::path::Path;
 use std::sync::{Arc, Mutex};
 
 use crate::cache::hint::Hint;
+use crate::cache::ir::{self, MetadataVisitor};
 use crate::cache::mapping::Mapping;
 use crate::cache::superblock::*;
-use crate::cache::xml::{self, MetadataVisitor};
+use crate::cache::xml;
 use crate::io_engine::{AsyncIoEngine, IoEngine, SyncIoEngine};
 use crate::pdata::array::{self, ArrayBlock};
 use crate::pdata::array_walker::*;
@@ -58,7 +59,7 @@ mod format1 {
                     continue;
                 }
 
-                let m = xml::Map {
+                let m = ir::Map {
                     cblock,
                     oblock: map.oblock,
                     dirty: map.is_dirty(),
@@ -133,7 +134,7 @@ mod format2 {
                     // default to dirty if the bitset is damaged
                     dirty = true;
                 }
-                let m = xml::Map {
+                let m = ir::Map {
                     cblock,
                     oblock: map.oblock,
                     dirty,
@@ -175,7 +176,7 @@ impl<'a> ArrayVisitor<Hint> for HintEmitter<'a> {
                 continue;
             }
 
-            let h = xml::Hint {
+            let h = ir::Hint {
                 cblock,
                 data: hint.hint.to_vec(),
             };
@@ -226,7 +227,7 @@ fn dump_metadata(
     let engine = &ctx.engine;
 
     let mut out = xml::XmlWriter::new(w);
-    let xml_sb = xml::Superblock {
+    let xml_sb = ir::Superblock {
         uuid: "".to_string(),
         block_size: sb.data_block_size,
         nr_cache_blocks: sb.cache_blocks,

--- a/src/cache/ir.rs
+++ b/src/cache/ir.rs
@@ -1,0 +1,60 @@
+use anyhow::Result;
+
+//------------------------------------------
+
+#[derive(Clone)]
+pub struct Superblock {
+    pub uuid: String,
+    pub block_size: u32,
+    pub nr_cache_blocks: u32,
+    pub policy: String,
+    pub hint_width: u32,
+}
+
+#[derive(Clone)]
+pub struct Map {
+    pub cblock: u32,
+    pub oblock: u64,
+    pub dirty: bool,
+}
+
+#[derive(Clone)]
+pub struct Hint {
+    pub cblock: u32,
+    pub data: Vec<u8>,
+}
+
+#[derive(Clone)]
+pub struct Discard {
+    pub begin: u64,
+    pub end: u64,
+}
+
+//------------------------------------------
+
+#[derive(Clone)]
+pub enum Visit {
+    Continue,
+    Stop,
+}
+
+pub trait MetadataVisitor {
+    fn superblock_b(&mut self, sb: &Superblock) -> Result<Visit>;
+    fn superblock_e(&mut self) -> Result<Visit>;
+
+    fn mappings_b(&mut self) -> Result<Visit>;
+    fn mappings_e(&mut self) -> Result<Visit>;
+    fn mapping(&mut self, m: &Map) -> Result<Visit>;
+
+    fn hints_b(&mut self) -> Result<Visit>;
+    fn hints_e(&mut self) -> Result<Visit>;
+    fn hint(&mut self, h: &Hint) -> Result<Visit>;
+
+    fn discards_b(&mut self) -> Result<Visit>;
+    fn discards_e(&mut self) -> Result<Visit>;
+    fn discard(&mut self, d: &Discard) -> Result<Visit>;
+
+    fn eof(&mut self) -> Result<Visit>;
+}
+
+//------------------------------------------

--- a/src/cache/mod.rs
+++ b/src/cache/mod.rs
@@ -3,6 +3,7 @@ pub mod dump;
 pub mod hint;
 pub mod ir;
 pub mod mapping;
+pub mod repair;
 pub mod restore;
 pub mod superblock;
 pub mod xml;

--- a/src/cache/mod.rs
+++ b/src/cache/mod.rs
@@ -1,6 +1,7 @@
 pub mod check;
 pub mod dump;
 pub mod hint;
+pub mod ir;
 pub mod mapping;
 pub mod restore;
 pub mod superblock;

--- a/src/cache/repair.rs
+++ b/src/cache/repair.rs
@@ -1,0 +1,68 @@
+use anyhow::Result;
+use std::path::Path;
+use std::sync::Arc;
+
+use crate::cache::dump::*;
+use crate::cache::restore::*;
+use crate::cache::superblock::*;
+use crate::io_engine::*;
+use crate::pdata::space_map::*;
+use crate::report::*;
+use crate::write_batcher::*;
+
+//------------------------------------------
+
+pub struct CacheRepairOptions<'a> {
+    pub input: &'a Path,
+    pub output: &'a Path,
+    pub async_io: bool,
+    pub report: Arc<Report>,
+}
+
+struct Context {
+    _report: Arc<Report>,
+    engine_in: Arc<dyn IoEngine + Send + Sync>,
+    engine_out: Arc<dyn IoEngine + Send + Sync>,
+}
+
+const MAX_CONCURRENT_IO: u32 = 1024;
+
+fn new_context(opts: &CacheRepairOptions) -> Result<Context> {
+    let engine_in: Arc<dyn IoEngine + Send + Sync>;
+    let engine_out: Arc<dyn IoEngine + Send + Sync>;
+
+    if opts.async_io {
+        engine_in = Arc::new(AsyncIoEngine::new(opts.input, MAX_CONCURRENT_IO, true)?);
+        engine_out = Arc::new(AsyncIoEngine::new(opts.output, MAX_CONCURRENT_IO, true)?);
+    } else {
+        let nr_threads = std::cmp::max(8, num_cpus::get() * 2);
+        engine_in = Arc::new(SyncIoEngine::new(opts.input, nr_threads, true)?);
+        engine_out = Arc::new(SyncIoEngine::new(opts.output, nr_threads, true)?);
+    }
+
+    Ok(Context {
+        _report: opts.report.clone(),
+        engine_in,
+        engine_out,
+    })
+}
+
+//------------------------------------------
+
+pub fn repair(opts: CacheRepairOptions) -> Result<()> {
+    let ctx = new_context(&opts)?;
+
+    let sb = read_superblock(ctx.engine_in.as_ref(), SUPERBLOCK_LOCATION)?;
+
+    let sm = core_sm(ctx.engine_out.get_nr_blocks(), u32::MAX);
+    let mut w = WriteBatcher::new(
+        ctx.engine_out.clone(),
+        sm.clone(),
+        ctx.engine_out.get_batch_size(),
+    );
+    let mut restorer = Restorer::new(&mut w);
+
+    dump_metadata(ctx.engine_in, &mut restorer, &sb, true)
+}
+
+//------------------------------------------

--- a/src/cache/restore.rs
+++ b/src/cache/restore.rs
@@ -1,4 +1,4 @@
-use anyhow::{anyhow, Result};
+use anyhow::Result;
 
 use std::convert::TryInto;
 use std::fs::OpenOptions;
@@ -56,15 +56,7 @@ fn mk_context(opts: &CacheRestoreOptions) -> anyhow::Result<Context> {
 
 //------------------------------------------
 
-struct RestoreResult {
-    sb: ir::Superblock,
-    mapping_root: u64,
-    dirty_root: Option<u64>,
-    hint_root: u64,
-    discard_root: u64,
-}
-
-struct Restorer<'a> {
+pub struct Restorer<'a> {
     write_batcher: &'a mut WriteBatcher,
     sb: Option<ir::Superblock>,
     mapping_builder: Option<ArrayBuilder<Mapping>>,
@@ -78,7 +70,7 @@ struct Restorer<'a> {
 }
 
 impl<'a> Restorer<'a> {
-    fn new(w: &'a mut WriteBatcher) -> Restorer<'a> {
+    pub fn new(w: &'a mut WriteBatcher) -> Restorer<'a> {
         Restorer {
             write_batcher: w,
             sb: None,
@@ -93,22 +85,42 @@ impl<'a> Restorer<'a> {
         }
     }
 
-    fn get_result(self) -> Result<RestoreResult> {
-        self.write_batcher.flush()?;
+    fn finalize(&mut self) -> Result<()> {
+        // build metadata space map
+        let metadata_sm_root = build_metadata_sm(self.write_batcher)?;
 
-        if self.sb.is_none() || self.discard_root.is_none() {
-            return Err(anyhow!("No superblock found in xml file"));
-        }
-        if self.mapping_root.is_none() || self.hint_root.is_none() {
-            return Err(anyhow!("No mappings or hints sections in xml file"));
-        }
-        Ok(RestoreResult {
-            sb: self.sb.unwrap(),
-            mapping_root: self.mapping_root.unwrap(),
-            dirty_root: self.dirty_root,
-            hint_root: self.hint_root.unwrap(),
-            discard_root: self.discard_root.unwrap(),
-        })
+        let sb = self.sb.as_ref().unwrap();
+        let mapping_root = self.mapping_root.as_ref().unwrap();
+        let hint_root = self.hint_root.as_ref().unwrap();
+        let discard_root = self.discard_root.as_ref().unwrap();
+        let sb = Superblock {
+            flags: SuperblockFlags {
+                clean_shutdown: true,
+                needs_check: false,
+            },
+            block: SUPERBLOCK_LOCATION,
+            version: 2,
+            policy_name: sb.policy.as_bytes().to_vec(),
+            policy_version: vec![2, 0, 0],
+            policy_hint_size: sb.hint_width,
+            metadata_sm_root,
+            mapping_root: *mapping_root,
+            dirty_root: self.dirty_root, // dirty_root is optional
+            hint_root: *hint_root,
+            discard_root: *discard_root,
+            discard_block_size: 0,
+            discard_nr_blocks: 0,
+            data_block_size: sb.block_size,
+            cache_blocks: sb.nr_cache_blocks,
+            compat_flags: 0,
+            compat_ro_flags: 0,
+            incompat_flags: 0,
+            read_hits: 0,
+            read_misses: 9,
+            write_hits: 0,
+            write_misses: 0,
+        };
+        write_superblock(self.write_batcher.engine.as_ref(), SUPERBLOCK_LOCATION, &sb)
     }
 }
 
@@ -127,6 +139,7 @@ impl<'a> MetadataVisitor for Restorer<'a> {
     }
 
     fn superblock_e(&mut self) -> Result<Visit> {
+        self.finalize()?;
         Ok(Visit::Continue)
     }
 
@@ -252,39 +265,6 @@ pub fn restore(opts: CacheRestoreOptions) -> Result<()> {
     // build cache mappings
     let mut restorer = Restorer::new(&mut w);
     xml::read(input, &mut restorer)?;
-    let result = restorer.get_result()?;
-
-    // build metadata space map
-    let metadata_sm_root = build_metadata_sm(&mut w)?;
-
-    let sb = Superblock {
-        flags: SuperblockFlags {
-            clean_shutdown: true,
-            needs_check: false,
-        },
-        block: SUPERBLOCK_LOCATION,
-        version: 2,
-        policy_name: result.sb.policy.as_bytes().to_vec(),
-        policy_version: vec![2, 0, 0],
-        policy_hint_size: result.sb.hint_width,
-        metadata_sm_root,
-        mapping_root: result.mapping_root,
-        dirty_root: result.dirty_root,
-        hint_root: result.hint_root,
-        discard_root: result.discard_root,
-        discard_block_size: 0,
-        discard_nr_blocks: 0,
-        data_block_size: result.sb.block_size,
-        cache_blocks: result.sb.nr_cache_blocks,
-        compat_flags: 0,
-        compat_ro_flags: 0,
-        incompat_flags: 0,
-        read_hits: 0,
-        read_misses: 9,
-        write_hits: 0,
-        write_misses: 0,
-    };
-    write_superblock(ctx.engine.as_ref(), SUPERBLOCK_LOCATION, &sb)?;
 
     Ok(())
 }

--- a/src/cache/xml.rs
+++ b/src/cache/xml.rs
@@ -6,62 +6,10 @@ use std::io::{Read, Write};
 use quick_xml::events::{BytesEnd, BytesStart, Event};
 use quick_xml::{Reader, Writer};
 
+use crate::cache::ir::*;
 use crate::xml::*;
 
 //---------------------------------------
-
-#[derive(Clone)]
-pub struct Superblock {
-    pub uuid: String,
-    pub block_size: u32,
-    pub nr_cache_blocks: u32,
-    pub policy: String,
-    pub hint_width: u32,
-}
-
-#[derive(Clone)]
-pub struct Map {
-    pub cblock: u32,
-    pub oblock: u64,
-    pub dirty: bool,
-}
-
-#[derive(Clone)]
-pub struct Hint {
-    pub cblock: u32,
-    pub data: Vec<u8>,
-}
-
-#[derive(Clone)]
-pub struct Discard {
-    pub begin: u64,
-    pub end: u64,
-}
-
-#[derive(Clone)]
-pub enum Visit {
-    Continue,
-    Stop,
-}
-
-pub trait MetadataVisitor {
-    fn superblock_b(&mut self, sb: &Superblock) -> Result<Visit>;
-    fn superblock_e(&mut self) -> Result<Visit>;
-
-    fn mappings_b(&mut self) -> Result<Visit>;
-    fn mappings_e(&mut self) -> Result<Visit>;
-    fn mapping(&mut self, m: &Map) -> Result<Visit>;
-
-    fn hints_b(&mut self) -> Result<Visit>;
-    fn hints_e(&mut self) -> Result<Visit>;
-    fn hint(&mut self, h: &Hint) -> Result<Visit>;
-
-    fn discards_b(&mut self) -> Result<Visit>;
-    fn discards_e(&mut self) -> Result<Visit>;
-    fn discard(&mut self, d: &Discard) -> Result<Visit>;
-
-    fn eof(&mut self) -> Result<Visit>;
-}
 
 pub struct XmlWriter<W: Write> {
     w: Writer<W>,

--- a/src/thin/ir.rs
+++ b/src/thin/ir.rs
@@ -1,0 +1,60 @@
+use anyhow::Result;
+
+//------------------------------------------
+
+#[derive(Clone)]
+pub struct Superblock {
+    pub uuid: String,
+    pub time: u32,
+    pub transaction: u64,
+    pub flags: Option<u32>,
+    pub version: Option<u32>,
+    pub data_block_size: u32,
+    pub nr_data_blocks: u64,
+    pub metadata_snap: Option<u64>,
+}
+
+#[derive(Clone)]
+pub struct Device {
+    pub dev_id: u32,
+    pub mapped_blocks: u64,
+    pub transaction: u64,
+    pub creation_time: u32,
+    pub snap_time: u32,
+}
+
+#[derive(Clone)]
+pub struct Map {
+    pub thin_begin: u64,
+    pub data_begin: u64,
+    pub time: u32,
+    pub len: u64,
+}
+
+//------------------------------------------
+
+#[derive(Clone)]
+pub enum Visit {
+    Continue,
+    Stop,
+}
+
+pub trait MetadataVisitor {
+    fn superblock_b(&mut self, sb: &Superblock) -> Result<Visit>;
+    fn superblock_e(&mut self) -> Result<Visit>;
+
+    // Defines a shared sub tree.  May only contain a 'map' (no 'ref' allowed).
+    fn def_shared_b(&mut self, name: &str) -> Result<Visit>;
+    fn def_shared_e(&mut self) -> Result<Visit>;
+
+    // A device contains a number of 'map' or 'ref' items.
+    fn device_b(&mut self, d: &Device) -> Result<Visit>;
+    fn device_e(&mut self) -> Result<Visit>;
+
+    fn map(&mut self, m: &Map) -> Result<Visit>;
+    fn ref_shared(&mut self, name: &str) -> Result<Visit>;
+
+    fn eof(&mut self) -> Result<Visit>;
+}
+
+//------------------------------------------

--- a/src/thin/metadata.rs
+++ b/src/thin/metadata.rs
@@ -1,0 +1,236 @@
+use anyhow::Result;
+use std::collections::{BTreeMap, BTreeSet};
+use std::sync::{Arc, Mutex};
+
+use crate::io_engine::IoEngine;
+use crate::pdata::btree::{self, *};
+use crate::pdata::btree_leaf_walker::*;
+use crate::pdata::btree_walker::*;
+use crate::pdata::space_map::*;
+use crate::thin::block_time::*;
+use crate::thin::device_detail::*;
+use crate::thin::runs::*;
+use crate::thin::superblock::*;
+
+//------------------------------------------
+
+type DefId = u64;
+type ThinId = u32;
+
+#[derive(Clone)]
+pub enum Entry {
+    Leaf(u64),
+    Ref(DefId),
+}
+
+#[derive(Clone)]
+pub struct Mapping {
+    pub kr: KeyRange,
+    pub entries: Vec<Entry>,
+}
+
+#[derive(Clone)]
+pub struct Device {
+    pub thin_id: ThinId,
+    pub detail: DeviceDetail,
+    pub map: Mapping,
+}
+
+#[derive(Clone)]
+pub struct Def {
+    pub def_id: DefId,
+    pub map: Mapping,
+}
+
+#[derive(Clone)]
+pub struct Metadata {
+    pub defs: Vec<Def>,
+    pub devs: Vec<Device>,
+}
+
+//------------------------------------------
+
+struct CollectLeaves {
+    leaves: Vec<Entry>,
+}
+
+impl CollectLeaves {
+    fn new() -> CollectLeaves {
+        CollectLeaves { leaves: Vec::new() }
+    }
+}
+
+impl LeafVisitor<BlockTime> for CollectLeaves {
+    fn visit(&mut self, _kr: &KeyRange, b: u64) -> btree::Result<()> {
+        self.leaves.push(Entry::Leaf(b));
+        Ok(())
+    }
+
+    fn visit_again(&mut self, b: u64) -> btree::Result<()> {
+        self.leaves.push(Entry::Ref(b));
+        Ok(())
+    }
+
+    fn end_walk(&mut self) -> btree::Result<()> {
+        Ok(())
+    }
+}
+
+fn collect_leaves(
+    engine: Arc<dyn IoEngine + Send + Sync>,
+    roots: &BTreeSet<u64>,
+) -> Result<BTreeMap<u64, Vec<Entry>>> {
+    let mut map: BTreeMap<u64, Vec<Entry>> = BTreeMap::new();
+    let mut sm = RestrictedSpaceMap::new(engine.get_nr_blocks());
+
+    for r in roots {
+        let mut w = LeafWalker::new(engine.clone(), &mut sm, false);
+        let mut v = CollectLeaves::new();
+        let mut path = vec![0];
+        w.walk::<CollectLeaves, BlockTime>(&mut path, &mut v, *r)?;
+
+        map.insert(*r, v.leaves);
+    }
+
+    Ok(map)
+}
+
+//------------------------------------------
+
+pub fn build_metadata(
+    engine: Arc<dyn IoEngine + Send + Sync>,
+    sb: &Superblock,
+) -> Result<Metadata> {
+    let mut path = vec![0];
+
+    // report.set_title("Reading device details");
+    let details = btree_to_map::<DeviceDetail>(&mut path, engine.clone(), true, sb.details_root)?;
+
+    // report.set_title("Reading mappings roots");
+    let roots;
+    {
+        let sm = Arc::new(Mutex::new(RestrictedSpaceMap::new(engine.get_nr_blocks())));
+        roots =
+            btree_to_map_with_path::<u64>(&mut path, engine.clone(), sm, true, sb.mapping_root)?;
+    }
+
+    // report.set_title(&format!("Collecting leaves for {} roots", roots.len()));
+    let mapping_roots = roots.values().map(|(_, root)| *root).collect();
+    let entry_map = collect_leaves(engine.clone(), &mapping_roots)?;
+
+    let defs = Vec::new();
+    let mut devs = Vec::new();
+    for (thin_id, (_path, root)) in roots {
+        let id = thin_id as u64;
+        let detail = details.get(&id).expect("couldn't find device details");
+        let es = entry_map.get(&root).unwrap();
+        let kr = KeyRange::new(); // FIXME: finish
+        devs.push(Device {
+            thin_id: thin_id as u32,
+            detail: *detail,
+            map: Mapping {
+                kr,
+                entries: es.to_vec(),
+            },
+        });
+    }
+
+    Ok(Metadata { defs, devs })
+}
+
+//------------------------------------------
+
+fn gather_entries(g: &mut Gatherer, es: &[Entry]) {
+    g.new_seq();
+    for e in es {
+        match e {
+            Entry::Leaf(b) => {
+                g.next(*b);
+            }
+            Entry::Ref(_id) => {
+                g.new_seq();
+            }
+        }
+    }
+}
+
+fn build_runs(devs: &[Device]) -> BTreeMap<u64, Vec<u64>> {
+    let mut g = Gatherer::new();
+
+    for d in devs {
+        gather_entries(&mut g, &d.map.entries);
+    }
+
+    // The runs become defs that just contain leaves.
+    let mut runs = BTreeMap::new();
+    for run in g.gather() {
+        runs.insert(run[0], run);
+    }
+
+    runs
+}
+
+fn entries_to_runs(runs: &BTreeMap<u64, Vec<u64>>, es: &[Entry]) -> Vec<Entry> {
+    use Entry::*;
+
+    let mut result = Vec::new();
+    let mut entry_index = 0;
+    while entry_index < es.len() {
+        match es[entry_index] {
+            Ref(id) => {
+                result.push(Ref(id));
+                entry_index += 1;
+            }
+            Leaf(b) => {
+                if let Some(run) = runs.get(&b) {
+                    result.push(Ref(b));
+                    entry_index += run.len();
+                } else {
+                    result.push(Leaf(b));
+                    entry_index += 1;
+                }
+            }
+        }
+    }
+
+    result
+}
+
+fn build_defs(runs: BTreeMap<u64, Vec<u64>>) -> Vec<Def> {
+    let mut defs = Vec::new();
+    for (head, run) in runs.iter() {
+        let kr = KeyRange::new();
+        let entries: Vec<Entry> = run.iter().map(|b| Entry::Leaf(*b)).collect();
+        defs.push(Def {
+            def_id: *head,
+            map: Mapping { kr, entries },
+        });
+    }
+
+    defs
+}
+
+// FIXME: do we really need to track kr?
+// FIXME: I think this may be better done as part of restore.
+pub fn optimise_metadata(md: Metadata) -> Result<Metadata> {
+    let runs = build_runs(&md.devs);
+    eprintln!("{} runs", runs.len());
+
+    // Expand old devs to use the new atomic runs
+    let mut devs = Vec::new();
+    for d in &md.devs {
+        let kr = KeyRange::new();
+        let entries = entries_to_runs(&runs, &d.map.entries);
+        devs.push(Device {
+            thin_id: d.thin_id,
+            detail: d.detail,
+            map: Mapping { kr, entries },
+        });
+    }
+
+    let defs = build_defs(runs);
+
+    Ok(Metadata { defs, devs })
+}
+
+//------------------------------------------

--- a/src/thin/mod.rs
+++ b/src/thin/mod.rs
@@ -2,6 +2,7 @@ pub mod block_time;
 pub mod check;
 pub mod device_detail;
 pub mod dump;
+pub mod ir;
 pub mod restore;
 pub mod runs;
 pub mod superblock;

--- a/src/thin/mod.rs
+++ b/src/thin/mod.rs
@@ -4,6 +4,7 @@ pub mod device_detail;
 pub mod dump;
 pub mod ir;
 pub mod metadata;
+pub mod repair;
 pub mod restore;
 pub mod runs;
 pub mod superblock;

--- a/src/thin/mod.rs
+++ b/src/thin/mod.rs
@@ -3,6 +3,7 @@ pub mod check;
 pub mod device_detail;
 pub mod dump;
 pub mod ir;
+pub mod metadata;
 pub mod restore;
 pub mod runs;
 pub mod superblock;

--- a/src/thin/repair.rs
+++ b/src/thin/repair.rs
@@ -1,0 +1,71 @@
+use anyhow::Result;
+use std::path::Path;
+use std::sync::Arc;
+
+use crate::io_engine::*;
+use crate::pdata::space_map::*;
+use crate::report::*;
+use crate::thin::dump::*;
+use crate::thin::metadata::*;
+use crate::thin::restore::*;
+use crate::thin::superblock::*;
+use crate::write_batcher::*;
+
+//------------------------------------------
+
+pub struct ThinRepairOptions<'a> {
+    pub input: &'a Path,
+    pub output: &'a Path,
+    pub async_io: bool,
+    pub report: Arc<Report>,
+}
+
+struct Context {
+    report: Arc<Report>,
+    engine_in: Arc<dyn IoEngine + Send + Sync>,
+    engine_out: Arc<dyn IoEngine + Send + Sync>,
+}
+
+const MAX_CONCURRENT_IO: u32 = 1024;
+
+fn new_context(opts: &ThinRepairOptions) -> Result<Context> {
+    let engine_in: Arc<dyn IoEngine + Send + Sync>;
+    let engine_out: Arc<dyn IoEngine + Send + Sync>;
+
+    if opts.async_io {
+        engine_in = Arc::new(AsyncIoEngine::new(opts.input, MAX_CONCURRENT_IO, true)?);
+        engine_out = Arc::new(AsyncIoEngine::new(opts.output, MAX_CONCURRENT_IO, true)?);
+    } else {
+        let nr_threads = std::cmp::max(8, num_cpus::get() * 2);
+        engine_in = Arc::new(SyncIoEngine::new(opts.input, nr_threads, true)?);
+        engine_out = Arc::new(SyncIoEngine::new(opts.output, nr_threads, true)?);
+    }
+
+    Ok(Context {
+        report: opts.report.clone(),
+        engine_in,
+        engine_out,
+    })
+}
+
+//------------------------------------------
+
+pub fn repair(opts: ThinRepairOptions) -> Result<()> {
+    let ctx = new_context(&opts)?;
+
+    let sb = read_superblock(ctx.engine_in.as_ref(), SUPERBLOCK_LOCATION)?;
+    let md = build_metadata(ctx.engine_in.clone(), &sb)?;
+    let md = optimise_metadata(md)?;
+
+    let sm = core_sm(ctx.engine_out.get_nr_blocks(), u32::MAX);
+    let mut w = WriteBatcher::new(
+        ctx.engine_out.clone(),
+        sm.clone(),
+        ctx.engine_out.get_batch_size(),
+    );
+    let mut restorer = Restorer::new(&mut w, ctx.report);
+
+    dump_metadata(ctx.engine_in, &mut restorer, &sb, &md)
+}
+
+//------------------------------------------

--- a/src/thin/restore.rs
+++ b/src/thin/restore.rs
@@ -10,6 +10,7 @@ use std::sync::{Arc, Mutex};
 use crate::io_engine::*;
 use crate::pdata::btree_builder::*;
 use crate::pdata::space_map::*;
+use crate::pdata::space_map_common::SMRoot;
 use crate::pdata::space_map_disk::*;
 use crate::pdata::space_map_metadata::*;
 use crate::pdata::unpack::Pack;
@@ -58,13 +59,7 @@ impl std::fmt::Display for MappedSection {
 
 //------------------------------------------
 
-struct RestoreResult {
-    sb: ir::Superblock,
-    devices: BTreeMap<u32, (DeviceDetail, u64)>,
-    data_sm: Arc<Mutex<dyn SpaceMap>>,
-}
-
-struct Restorer<'a> {
+pub struct Restorer<'a> {
     w: &'a mut WriteBatcher,
     report: Arc<Report>,
 
@@ -81,7 +76,7 @@ struct Restorer<'a> {
 }
 
 impl<'a> Restorer<'a> {
-    fn new(w: &'a mut WriteBatcher, report: Arc<Report>) -> Self {
+    pub fn new(w: &'a mut WriteBatcher, report: Arc<Report>) -> Self {
         Restorer {
             w,
             report,
@@ -92,17 +87,6 @@ impl<'a> Restorer<'a> {
             devices: BTreeMap::new(),
             data_sm: None,
         }
-    }
-
-    fn get_result(self) -> Result<RestoreResult> {
-        if self.sb.is_none() {
-            return Err(anyhow!("No superblock found in xml file"));
-        }
-        Ok(RestoreResult {
-            sb: self.sb.unwrap(),
-            devices: self.devices,
-            data_sm: self.data_sm.unwrap(),
-        })
     }
 
     fn begin_section(&mut self, section: MappedSection) -> Result<Visit> {
@@ -134,17 +118,65 @@ impl<'a> Restorer<'a> {
             Err(anyhow!(msg))
         }
     }
+
+    // Build the device details and the top level mapping trees
+    fn build_device_details(&mut self) -> Result<(u64, u64)> {
+        let mut details_builder: BTreeBuilder<DeviceDetail> =
+            BTreeBuilder::new(Box::new(NoopRC {}));
+        let mut dev_builder: BTreeBuilder<u64> = BTreeBuilder::new(Box::new(NoopRC {}));
+        for (thin_id, (detail, root)) in self.devices.iter() {
+            details_builder.push_value(self.w, *thin_id as u64, *detail)?;
+            dev_builder.push_value(self.w, *thin_id as u64, *root)?;
+        }
+        let details_root = details_builder.complete(self.w)?;
+        let mapping_root = dev_builder.complete(self.w)?;
+
+        Ok((details_root, mapping_root))
+    }
+
+    fn finalize(&mut self) -> Result<()> {
+        let (details_root, mapping_root) = self.build_device_details()?;
+
+        // Build data space map
+        let data_sm = self.data_sm.as_ref().unwrap();
+        let data_sm_root = build_data_sm(self.w, data_sm.lock().unwrap().deref())?;
+
+        // Build metadata space map
+        let (metadata_sm, metadata_sm_root) = build_metadata_sm(self.w)?;
+
+        // Write the superblock
+        let sb = self.sb.as_ref().unwrap();
+        let sb = superblock::Superblock {
+            flags: SuperblockFlags { needs_check: false },
+            block: SUPERBLOCK_LOCATION,
+            version: 2,
+            time: sb.time as u32,
+            transaction_id: sb.transaction,
+            metadata_snap: 0,
+            data_sm_root,
+            metadata_sm_root,
+            mapping_root,
+            details_root,
+            data_block_size: sb.data_block_size,
+            nr_metadata_blocks: metadata_sm.nr_blocks,
+        };
+        write_superblock(self.w.engine.as_ref(), SUPERBLOCK_LOCATION, &sb)
+    }
 }
 
 impl<'a> MetadataVisitor for Restorer<'a> {
     fn superblock_b(&mut self, sb: &ir::Superblock) -> Result<Visit> {
         self.sb = Some(sb.clone());
         self.data_sm = Some(core_sm(sb.nr_data_blocks, u32::MAX));
-        self.w.alloc()?;
+        let b = self.w.alloc()?;
+        if b.loc != SUPERBLOCK_LOCATION {
+            return Err(anyhow!("superblock was occupied"));
+        }
         Ok(Visit::Continue)
     }
 
     fn superblock_e(&mut self) -> Result<Visit> {
+        self.finalize()?;
         Ok(Visit::Continue)
     }
 
@@ -249,13 +281,13 @@ fn build_data_sm(w: &mut WriteBatcher, sm: &dyn SpaceMap) -> Result<Vec<u8>> {
 
 /// Writes the metadata space map to disk.  Returns the space map root that needs
 /// to be written to the superblock.
-fn build_metadata_sm(w: &mut WriteBatcher) -> Result<Vec<u8>> {
+fn build_metadata_sm(w: &mut WriteBatcher) -> Result<(SMRoot, Vec<u8>)> {
     let mut sm_root = vec![0u8; SPACE_MAP_ROOT_SIZE];
     let mut cur = Cursor::new(&mut sm_root);
     let r = write_metadata_sm(w)?;
     r.pack(&mut cur)?;
 
-    Ok(sm_root)
+    Ok((r, sm_root))
 }
 
 //------------------------------------------
@@ -303,42 +335,8 @@ pub fn restore(opts: ThinRestoreOptions) -> Result<()> {
 
     let sm = core_sm(ctx.engine.get_nr_blocks(), max_count);
     let mut w = WriteBatcher::new(ctx.engine.clone(), sm.clone(), ctx.engine.get_batch_size());
-    let mut restorer = Restorer::new(&mut w, ctx.report.clone());
+    let mut restorer = Restorer::new(&mut w, ctx.report);
     xml::read(input, &mut restorer)?;
-    let result = restorer.get_result()?;
-
-    // Build the device details and top level mapping tree
-    let mut details_builder: BTreeBuilder<DeviceDetail> = BTreeBuilder::new(Box::new(NoopRC {}));
-    let mut dev_builder: BTreeBuilder<u64> = BTreeBuilder::new(Box::new(NoopRC {}));
-    for (thin_id, (detail, root)) in &result.devices {
-        details_builder.push_value(&mut w, *thin_id as u64, *detail)?;
-        dev_builder.push_value(&mut w, *thin_id as u64, *root)?;
-    }
-    let details_root = details_builder.complete(&mut w)?;
-    let mapping_root = dev_builder.complete(&mut w)?;
-
-    // Build data space map
-    let data_sm_root = build_data_sm(&mut w, result.data_sm.lock().unwrap().deref())?;
-
-    // Build metadata space map
-    let metadata_sm_root = build_metadata_sm(&mut w)?;
-
-    // Write the superblock
-    let sb = superblock::Superblock {
-        flags: SuperblockFlags { needs_check: false },
-        block: SUPERBLOCK_LOCATION,
-        version: 2,
-        time: result.sb.time as u32,
-        transaction_id: result.sb.transaction,
-        metadata_snap: 0,
-        data_sm_root,
-        metadata_sm_root,
-        mapping_root,
-        details_root,
-        data_block_size: result.sb.data_block_size,
-        nr_metadata_blocks: ctx.engine.get_nr_blocks(),
-    };
-    write_superblock(ctx.engine.as_ref(), SUPERBLOCK_LOCATION, &sb)?;
 
     Ok(())
 }

--- a/tests/common/cache_xml_generator.rs
+++ b/tests/common/cache_xml_generator.rs
@@ -3,12 +3,13 @@ use rand::prelude::*;
 use std::collections::HashSet;
 use std::fs::OpenOptions;
 use std::path::Path;
+use thinp::cache::ir::{self, MetadataVisitor};
 use thinp::cache::xml;
 
 //------------------------------------------
 
 pub trait XmlGen {
-    fn generate_xml(&mut self, v: &mut dyn xml::MetadataVisitor) -> Result<()>;
+    fn generate_xml(&mut self, v: &mut dyn MetadataVisitor) -> Result<()>;
 }
 
 pub fn write_xml(path: &Path, g: &mut dyn XmlGen) -> Result<()> {
@@ -50,8 +51,8 @@ impl CacheGen {
 }
 
 impl XmlGen for CacheGen {
-    fn generate_xml(&mut self, v: &mut dyn xml::MetadataVisitor) -> Result<()> {
-        v.superblock_b(&xml::Superblock {
+    fn generate_xml(&mut self, v: &mut dyn MetadataVisitor) -> Result<()> {
+        v.superblock_b(&ir::Superblock {
             uuid: "".to_string(),
             block_size: self.block_size,
             nr_cache_blocks: self.nr_cache_blocks,
@@ -77,7 +78,7 @@ impl XmlGen for CacheGen {
 
                 used.insert(oblock);
                 // FIXME: dirty should vary
-                v.mapping(&xml::Map {
+                v.mapping(&ir::Map {
                     cblock: cblocks[n as usize],
                     oblock,
                     dirty: false,

--- a/tests/common/input_arg.rs
+++ b/tests/common/input_arg.rs
@@ -63,7 +63,7 @@ where
     P: InputProgram<'a>,
 {
     let args: [&str; 0] = [];
-    let stderr = run_fail(P::path(), &args)?;
+    let stderr = run_fail(P::path(), args)?;
     assert!(stderr.contains(P::missing_input_arg()));
     Ok(())
 }
@@ -85,8 +85,7 @@ where
     let mut td = TestDir::new()?;
     let output = mk_zeroed_md(&mut td)?;
     ensure_untouched(&output, || {
-        let args = args!["-o", &output];
-        let stderr = run_fail(P::path(), &args)?;
+        let stderr = run_fail(P::path(), args!["-o", &output])?;
         assert!(stderr.contains(P::missing_input_arg()));
         Ok(())
     })

--- a/tests/common/thin.rs
+++ b/tests/common/thin.rs
@@ -28,8 +28,7 @@ pub fn mk_valid_md(td: &mut TestDir) -> Result<PathBuf> {
     write_xml(&xml, &mut gen)?;
 
     let _file = file_utils::create_sized_file(&md, 4096 * 4096);
-    let args = args!["-i", &xml, "-o", &md];
-    run_ok(THIN_RESTORE, &args)?;
+    run_ok(THIN_RESTORE, args!["-i", &xml, "-o", &md])?;
 
     Ok(md)
 }
@@ -40,11 +39,11 @@ pub fn mk_valid_md(td: &mut TestDir) -> Result<PathBuf> {
 pub fn prep_metadata(td: &mut TestDir) -> Result<PathBuf> {
     let md = mk_zeroed_md(td)?;
     let args = args!["-o", &md, "--format", "--nr-data-blocks", "102400"];
-    run_ok(THIN_GENERATE_METADATA, &args)?;
+    run_ok(THIN_GENERATE_METADATA, args)?;
 
     // Create a 2GB device
     let args = args!["-o", &md, "--create-thin", "1"];
-    run_ok(THIN_GENERATE_METADATA, &args)?;
+    run_ok(THIN_GENERATE_METADATA, args)?;
     let args = args![
         "-o",
         &md,
@@ -55,7 +54,7 @@ pub fn prep_metadata(td: &mut TestDir) -> Result<PathBuf> {
         "--rw=randwrite",
         "--seq-nr=16"
     ];
-    run_ok(THIN_GENERATE_MAPPINGS, &args)?;
+    run_ok(THIN_GENERATE_MAPPINGS, args)?;
 
     // Take a few snapshots.
     let mut snap_id = 2;
@@ -63,7 +62,7 @@ pub fn prep_metadata(td: &mut TestDir) -> Result<PathBuf> {
         // take a snapshot
         let snap_id_str = snap_id.to_string();
         let args = args!["-o", &md, "--create-snap", &snap_id_str, "--origin", "1"];
-        run_ok(THIN_GENERATE_METADATA, &args)?;
+        run_ok(THIN_GENERATE_METADATA, args)?;
 
         // partially overwrite the origin (64MB)
         let args = args![
@@ -78,7 +77,7 @@ pub fn prep_metadata(td: &mut TestDir) -> Result<PathBuf> {
             "--rw=randwrite",
             "--seq-nr=16"
         ];
-        run_ok(THIN_GENERATE_MAPPINGS, &args)?;
+        run_ok(THIN_GENERATE_MAPPINGS, args)?;
         snap_id += 1;
     }
 
@@ -87,7 +86,7 @@ pub fn prep_metadata(td: &mut TestDir) -> Result<PathBuf> {
 
 pub fn set_needs_check(md: &PathBuf) -> Result<()> {
     let args = args!["-o", &md, "--set-needs-check"];
-    run_ok(THIN_GENERATE_METADATA, &args)?;
+    run_ok(THIN_GENERATE_METADATA, args)?;
     Ok(())
 }
 
@@ -111,7 +110,7 @@ pub fn generate_metadata_leaks(
         "--actual",
         &actual_str
     ];
-    run_ok(THIN_GENERATE_DAMAGE, &args)?;
+    run_ok(THIN_GENERATE_DAMAGE, args)?;
 
     Ok(())
 }

--- a/tests/thin_shrink.rs
+++ b/tests/thin_shrink.rs
@@ -6,7 +6,8 @@ use std::io::{Cursor, Read, Seek, SeekFrom, Write};
 use std::path::Path;
 
 use thinp::file_utils;
-use thinp::thin::xml::{self, Visit};
+use thinp::thin::ir::{self, MetadataVisitor, Visit};
+use thinp::thin::xml;
 
 mod common;
 use common::test_dir::*;
@@ -91,8 +92,8 @@ struct ThinXmlVisitor<'a, V: ThinVisitor> {
     thin_id: Option<u32>,
 }
 
-impl<'a, V: ThinVisitor> xml::MetadataVisitor for ThinXmlVisitor<'a, V> {
-    fn superblock_b(&mut self, sb: &xml::Superblock) -> Result<Visit> {
+impl<'a, V: ThinVisitor> MetadataVisitor for ThinXmlVisitor<'a, V> {
+    fn superblock_b(&mut self, sb: &ir::Superblock) -> Result<Visit> {
         self.block_size = Some(sb.data_block_size);
         Ok(Visit::Continue)
     }
@@ -109,7 +110,7 @@ impl<'a, V: ThinVisitor> xml::MetadataVisitor for ThinXmlVisitor<'a, V> {
         todo!();
     }
 
-    fn device_b(&mut self, d: &xml::Device) -> Result<Visit> {
+    fn device_b(&mut self, d: &ir::Device) -> Result<Visit> {
         self.thin_id = Some(d.dev_id);
         Ok(Visit::Continue)
     }
@@ -118,7 +119,7 @@ impl<'a, V: ThinVisitor> xml::MetadataVisitor for ThinXmlVisitor<'a, V> {
         Ok(Visit::Continue)
     }
 
-    fn map(&mut self, m: &xml::Map) -> Result<Visit> {
+    fn map(&mut self, m: &ir::Map) -> Result<Visit> {
         for i in 0..m.len {
             let block = ThinBlock {
                 thin_id: self.thin_id.unwrap(),


### PR DESCRIPTION
- Clean up the optimization process of thin_dump
  * Use common leaf sequences to build shared-defs, thus remove previous code and comments about shared internals. (e.g., https://github.com/jthornber/thin-provisioning-tools/blob/main/src/thin/dump.rs#L251)
- Added thin_repair and cache_repair