### PR TITLE
[era_invalidate] Don't read the live metadata when the --metadata-snapshot option is provided

### DIFF
--- a/era/metadata.cc
+++ b/era/metadata.cc
@@ -44,7 +44,7 @@ metadata::metadata(block_manager::ptr bm, open_type ot)
 
 metadata::metadata(block_manager::ptr bm, block_address metadata_snap)
 {
-	open_metadata(bm);
+	open_metadata(bm, metadata_snap);
 }
 
 void


### PR DESCRIPTION
Until now, `era_invalidate` read the live metadata (superblock), instead of the metadata snapshot, when using the `--metadata-snapshot` parameter.

Fix this by passing the location of the metadata snapshot to `open_metadata()`, when a metadata snapshot is used.