### PR TITLE
Update Rust edition to 2021

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "thinp"
 version = "0.1.0"
 authors = ["Joe Thornber <ejt@redhat.com>"]
-edition = "2018"
+edition = "2021"
 license = "GPL3"
 
 [dependencies]


### PR DESCRIPTION
The version 2 resolver that comes with edition 2021 doesn't enable features in dev-dependencies unless necessary so that the dev-tools won't be compiled in non-testing builds.

References:
https://doc.rust-lang.org/edition-guide/rust-2021/default-cargo-resolver.html
https://doc.rust-lang.org/cargo/reference/features.html