### PR TITLE
Improve the process of find_roots() in thin_repair

### DIFF
--- a/src/bin/pdata_tools.rs
+++ b/src/bin/pdata_tools.rs
@@ -54,8 +54,8 @@ fn main_() -> io::Result<()> {
         io::Error::from_raw_os_error(libc::EINVAL)
     })?;
 
-    if let Some(i) = commands.iter().position(|c| cmd == c.name()) {
-        commands[i].run(&mut args)
+    if let Some(c) = commands.iter().find(|c| cmd == c.name()) {
+        c.run(&mut args)
     } else {
         eprintln!("unrecognised command");
         usage(&commands);

--- a/src/bin/pdata_tools_dev.rs
+++ b/src/bin/pdata_tools_dev.rs
@@ -35,8 +35,8 @@ fn main_() -> io::Result<()> {
         io::Error::from_raw_os_error(libc::EINVAL)
     })?;
 
-    if let Some(i) = commands.iter().position(|c| cmd == c.name()) {
-        commands[i].run(&mut args)
+    if let Some(c) = commands.iter().find(|c| cmd == c.name()) {
+        c.run(&mut args)
     } else {
         eprintln!("unrecognised command");
         usage(&commands);


### PR DESCRIPTION
These patches are specific to metadata with a great number of root candidates (e.g., bz2082197).
- Reduce the time complexity from O(n^2)  to O(n*log(n)) in average.
- Avoid repeated map lookup
