### PR TITLE
thin/cache_metadata_size fixes

### DIFF
--- a/doc/TODO.md
+++ b/doc/TODO.md
@@ -8,7 +8,7 @@ Items in the High or Medium sections should be done before the formal release. T
       (e.g., the quiet flag, LVM compatibility, etc.)
 - [x] thin_dump --skip-mappings
 - [x] thin_dump: Display hints on input error
-- [ ] Handle unexpected input values (zero or negative) in some program,
+- [x] Handle unexpected input values (zero or negative) in some program,
       e.g., `cache_metadata_size --block-size 0` causes floating point exception.
 
 ## Medium
@@ -28,7 +28,7 @@ Items in the High or Medium sections should be done before the formal release. T
 - [ ] thin_dump: The iops seems lower than the C++ version
 - [ ] thin_delta: Multi-threaded get_mappings()
 - [ ] cache_check: Multi-threaded checking
-- [ ] io_engine: Remove locks from SyncIoEngine
+- [x] io_engine: Remove locks from SyncIoEngine
 
 ## Low or Enhancements
 
@@ -45,6 +45,7 @@ Items in the High or Medium sections should be done before the formal release. T
 - [x] thin/cache/era_dump: Show output errors except the broken pipe error
 - [ ] thin/cache/era_repair: Clear superblock if the output is incompleted (commit 1dd7b454, bz1499781)
       (Is it really necessary? In addition, issuing IO in error handling routine seems not a good idea)
+- [ ] cache_writeback: Implement --list-failed-blocks
 
 ## RFEs
 

--- a/src/cache/metadata_size.rs
+++ b/src/cache/metadata_size.rs
@@ -6,14 +6,12 @@ pub struct CacheMetadataSizeOptions {
 }
 
 pub fn metadata_size(opts: &CacheMetadataSizeOptions) -> Result<u64> {
-    const SECTOR_SHIFT: u64 = 9; // 512 bytes per sector
     const BYTES_PER_BLOCK_SHIFT: u64 = 4; // 16 bytes for key and value
-    const TRANSACTION_OVERHEAD: u64 = 8192; // in sectors; 4 MB
+    const TRANSACTION_OVERHEAD: u64 = 4 * 1024 * 1024; // 4 MB
     const HINT_OVERHEAD_PER_BLOCK: u64 = 8; // 8 bytes for the key
 
-    let mapping_size = (opts.nr_blocks << BYTES_PER_BLOCK_SHIFT) >> SECTOR_SHIFT;
-    let hint_size =
-        (opts.nr_blocks * (opts.max_hint_width as u64 + HINT_OVERHEAD_PER_BLOCK)) >> SECTOR_SHIFT;
+    let mapping_size = opts.nr_blocks << BYTES_PER_BLOCK_SHIFT;
+    let hint_size = opts.nr_blocks * (opts.max_hint_width as u64 + HINT_OVERHEAD_PER_BLOCK);
 
     Ok(TRANSACTION_OVERHEAD + mapping_size + hint_size)
 }

--- a/src/cache/metadata_size.rs
+++ b/src/cache/metadata_size.rs
@@ -1,8 +1,23 @@
-use anyhow::Result;
+use anyhow::{anyhow, Result};
+
+const MIN_CACHE_BLOCK_SIZE: u64 = 32768;
+const MAX_CACHE_BLOCK_SIZE: u64 = 1073741824;
 
 pub struct CacheMetadataSizeOptions {
     pub nr_blocks: u64,
     pub max_hint_width: u32, // bytes
+}
+
+pub fn check_cache_block_size(block_size: u64) -> Result<()> {
+    if block_size == 0 || (block_size & (MIN_CACHE_BLOCK_SIZE - 1)) != 0 {
+        return Err(anyhow!("block size must be a multiple of 32 KiB"));
+    }
+
+    if block_size > MAX_CACHE_BLOCK_SIZE {
+        return Err(anyhow!("maximum block size is 1 GiB"));
+    }
+
+    Ok(())
 }
 
 pub fn metadata_size(opts: &CacheMetadataSizeOptions) -> Result<u64> {

--- a/src/commands/thin_metadata_size.rs
+++ b/src/commands/thin_metadata_size.rs
@@ -24,7 +24,7 @@ impl ThinMetadataSizeCommand {
                     .short('b')
                     .long("block-size")
                     .required(true)
-                    .value_name("SECTORS"),
+                    .value_name("SIZE[bskmg]"),
             )
             .arg(
                 Arg::new("POOL_SIZE")
@@ -32,7 +32,7 @@ impl ThinMetadataSizeCommand {
                     .short('s')
                     .long("pool-size")
                     .required(true)
-                    .value_name("SECTORS"),
+                    .value_name("SIZE[bskmgtp]"),
             )
             .arg(
                 Arg::new("MAX_THINS")
@@ -65,16 +65,19 @@ impl ThinMetadataSizeCommand {
     {
         let matches = self.cli().get_matches_from(args);
 
-        // TODO: handle unit suffix
-        let pool_size = matches.value_of_t_or_exit::<u64>("POOL_SIZE");
-        let block_size = matches.value_of_t_or_exit::<u32>("BLOCK_SIZE");
+        let pool_size = matches
+            .value_of_t_or_exit::<StorageSize>("POOL_SIZE")
+            .size_bytes();
+        let block_size = matches
+            .value_of_t_or_exit::<StorageSize>("BLOCK_SIZE")
+            .size_bytes();
         let max_thins = matches.value_of_t_or_exit::<u64>("MAX_THINS");
         let unit = matches.value_of_t_or_exit::<Units>("UNIT");
         let numeric_only = matches.is_present("NUMERIC_ONLY");
 
         (
             ThinMetadataSizeOptions {
-                nr_blocks: pool_size / block_size as u64,
+                nr_blocks: pool_size / block_size,
                 max_thins,
             },
             unit,

--- a/src/commands/thin_metadata_size.rs
+++ b/src/commands/thin_metadata_size.rs
@@ -17,6 +17,13 @@ impl ThinMetadataSizeCommand {
             .color(clap::ColorChoice::Never)
             .version(crate::version::tools_version())
             .about("Estimate the size of the metadata device needed for a given configuration.")
+            // flags
+            .arg(
+                Arg::new("NUMERIC_ONLY")
+                    .help("Output numeric value only")
+                    .short('n')
+                    .long("numeric-only"),
+            )
             // options
             .arg(
                 Arg::new("BLOCK_SIZE")
@@ -44,17 +51,11 @@ impl ThinMetadataSizeCommand {
             )
             .arg(
                 Arg::new("UNIT")
-                    .help("Specify the output unit")
+                    .help("Specify the output unit in {bskKmMgG}")
                     .short('u')
                     .long("unit")
                     .value_name("UNIT")
                     .default_value("sector"),
-            )
-            .arg(
-                Arg::new("NUMERIC_ONLY")
-                    .help("Output numeric value only")
-                    .short('n')
-                    .long("numeric-only"),
             )
     }
 
@@ -96,12 +97,12 @@ impl<'a> Command<'a> for ThinMetadataSizeCommand {
 
         match metadata_size(&opts) {
             Ok(size) => {
-                let size = to_units(size * 512, unit);
+                let size = to_units(size, unit);
                 if numeric_only {
                     println!("{}", size);
                 } else {
                     let mut name = unit.to_string();
-                    name.push('s');
+                    name.push('s'); // plural form
                     println!("{} {}", size, name);
                 }
                 Ok(())

--- a/src/thin/ls.rs
+++ b/src/thin/ls.rs
@@ -223,7 +223,7 @@ impl<'a> LsTable<'a> {
 
             let cell = match field {
                 Mapped | Exclusive | Shared => {
-                    let (val, unit) = to_pretty_print_units(val);
+                    let (val, unit) = to_pretty_print_size(val);
                     let mut s = val.to_string();
                     s.push_str(&unit.to_string_short());
                     s

--- a/src/thin/metadata_size.rs
+++ b/src/thin/metadata_size.rs
@@ -1,10 +1,25 @@
-use anyhow::Result;
+use anyhow::{anyhow, Result};
 
 use crate::math::div_up;
+
+const MIN_DATA_BLOCK_SIZE: u64 = 65536;
+const MAX_DATA_BLOCK_SIZE: u64 = 1073741824;
 
 pub struct ThinMetadataSizeOptions {
     pub nr_blocks: u64,
     pub max_thins: u64,
+}
+
+pub fn check_data_block_size(block_size: u64) -> Result<()> {
+    if block_size == 0 || (block_size & (MIN_DATA_BLOCK_SIZE - 1)) != 0 {
+        return Err(anyhow!("block size must be a multiple of 64 KiB"));
+    }
+
+    if block_size > MAX_DATA_BLOCK_SIZE {
+        return Err(anyhow!("maximum block size is 1 GiB"));
+    }
+
+    Ok(())
 }
 
 pub fn metadata_size(opts: &ThinMetadataSizeOptions) -> Result<u64> {

--- a/src/thin/metadata_size.rs
+++ b/src/thin/metadata_size.rs
@@ -9,7 +9,7 @@ pub struct ThinMetadataSizeOptions {
 
 pub fn metadata_size(opts: &ThinMetadataSizeOptions) -> Result<u64> {
     const ENTRIES_PER_NODE: u64 = 126; // assumed the mapping leaves are half populated
-    const BLOCK_SIZE: u64 = 8; // sectors
+    const BLOCK_SIZE: u64 = 4096; // bytes
 
     // size of all the leaf nodes for data mappings
     let mapping_size = div_up(opts.nr_blocks, ENTRIES_PER_NODE) * BLOCK_SIZE;

--- a/src/units.rs
+++ b/src/units.rs
@@ -3,7 +3,7 @@ use std::str::FromStr;
 
 //------------------------------------------
 
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, Debug, PartialEq)]
 pub enum Units {
     Byte,
     Sector,
@@ -28,14 +28,14 @@ impl Units {
         match self {
             Byte => 1,
             Sector => 512,
-            // base 2
+            // binary multiples
             Kibibyte => 1024,
             Mebibyte => 1048576,
             Gibibyte => 1073741824,
             Tebibyte => 1099511627776,
             Pebibyte => 1125899906842624,
             Exbibyte => 1152921504606846976,
-            // base 10
+            // decimal multiples
             Kilobyte => 1000,
             Megabyte => 1000000,
             Gigabyte => 1000000000,
@@ -49,17 +49,17 @@ impl Units {
         use Units::*;
 
         String::from(match self {
-            Byte => "",
+            Byte => "b",
             Sector => "s",
-            // base 2
+            // with IEC binary prefixes
             Kibibyte => "KiB",
             Mebibyte => "MiB",
             Gibibyte => "GiB",
             Tebibyte => "Tib",
             Pebibyte => "PiB",
             Exbibyte => "EiB",
-            // base 10
-            Kilobyte => "kB",
+            // with SI decimal prefixes
+            Kilobyte => "kB", // SI uses lower case 'k' to denote kilo
             Megabyte => "MB",
             Gigabyte => "GB",
             Terabyte => "TB",
@@ -77,19 +77,19 @@ impl FromStr for Units {
             "byte" | "b" => Ok(Units::Byte),
             "sector" | "s" => Ok(Units::Sector),
             // base 2
-            "kibibyte" | "k" => Ok(Units::Kibibyte),
-            "mibibyte" | "m" => Ok(Units::Mebibyte),
-            "gibibyte" | "g" => Ok(Units::Gibibyte),
-            "tebibyte" | "t" => Ok(Units::Tebibyte),
-            "pebibyte" | "p" => Ok(Units::Pebibyte),
-            "exbibyte" | "e" => Ok(Units::Exbibyte),
+            "kibibyte" | "KiB" | "k" => Ok(Units::Kibibyte),
+            "mibibyte" | "MiB" | "m" => Ok(Units::Mebibyte),
+            "gibibyte" | "GiB" | "g" => Ok(Units::Gibibyte),
+            "tebibyte" | "TiB" | "t" => Ok(Units::Tebibyte),
+            "pebibyte" | "PiB" | "p" => Ok(Units::Pebibyte),
+            "exbibyte" | "EiB" | "e" => Ok(Units::Exbibyte),
             // base 10
-            "kilobyte" | "K" => Ok(Units::Kilobyte),
-            "megabyte" | "M" => Ok(Units::Megabyte),
-            "gigabyte" | "G" => Ok(Units::Gigabyte),
-            "terabyte" | "T" => Ok(Units::Terabyte),
-            "petabyte" | "P" => Ok(Units::Petabyte),
-            "exabyte" | "E" => Ok(Units::Exabyte),
+            "kilobyte" | "kB" | "K" => Ok(Units::Kilobyte),
+            "megabyte" | "MB" | "M" => Ok(Units::Megabyte),
+            "gigabyte" | "GB" | "G" => Ok(Units::Gigabyte),
+            "terabyte" | "TB" | "T" => Ok(Units::Terabyte),
+            "petabyte" | "PB" | "P" => Ok(Units::Petabyte),
+            "exabyte" | "EB" | "E" => Ok(Units::Exabyte),
             _ => Err(anyhow!("Invalid unit specifier")),
         }
     }
@@ -120,32 +120,284 @@ impl ToString for Units {
     }
 }
 
-pub fn to_bytes(size: u64, unit: Units) -> u64 {
-    size * unit.size_bytes()
-}
-
 pub fn to_units(bytes: u64, unit: Units) -> f64 {
     bytes as f64 / unit.size_bytes() as f64
 }
 
-pub fn to_pretty_print_units(bytes: u64) -> (u64, Units) {
+//------------------------------------------
+
+#[derive(Debug, PartialEq)]
+pub struct StorageSize {
+    multiple: u64,
+    unit: Units,
+}
+
+impl StorageSize {
+    pub fn new(multiple: u64, unit: Units) -> anyhow::Result<Self> {
+        // use division since the unit might not be power of 2
+        let limit = u64::MAX / unit.size_bytes();
+        if multiple > limit {
+            return Err(anyhow!("value out of bounds"));
+        }
+
+        Ok(StorageSize { multiple, unit })
+    }
+
+    pub fn bytes(multiple: u64) -> anyhow::Result<Self> {
+        StorageSize::new(multiple, Units::Byte)
+    }
+
+    pub fn sectors(multiple: u64) -> anyhow::Result<Self> {
+        StorageSize::new(multiple, Units::Sector)
+    }
+
+    pub fn kib(multiple: u64) -> anyhow::Result<Self> {
+        StorageSize::new(multiple, Units::Kibibyte)
+    }
+
+    pub fn mib(multiple: u64) -> anyhow::Result<Self> {
+        StorageSize::new(multiple, Units::Mebibyte)
+    }
+
+    pub fn gib(multiple: u64) -> anyhow::Result<Self> {
+        StorageSize::new(multiple, Units::Gibibyte)
+    }
+
+    pub fn tib(multiple: u64) -> anyhow::Result<Self> {
+        StorageSize::new(multiple, Units::Tebibyte)
+    }
+
+    pub fn pib(multiple: u64) -> anyhow::Result<Self> {
+        StorageSize::new(multiple, Units::Pebibyte)
+    }
+
+    pub fn eib(multiple: u64) -> anyhow::Result<Self> {
+        StorageSize::new(multiple, Units::Exbibyte)
+    }
+
+    pub fn size_bytes(&self) -> u64 {
+        self.multiple * self.unit.size_bytes()
+    }
+}
+
+impl FromStr for StorageSize {
+    type Err = anyhow::Error;
+
+    // default to sectors
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let (multiple, unit) = if let Some(pos) = s.find(|c: char| !c.is_digit(10)) {
+            (s[..pos].parse::<u64>()?, s[pos..].parse::<Units>()?)
+        } else {
+            (s.parse::<u64>()?, Units::Sector)
+        };
+
+        StorageSize::new(multiple, unit)
+    }
+}
+
+impl ToString for StorageSize {
+    fn to_string(&self) -> String {
+        let mut s = self.multiple.to_string();
+        s.push_str(&self.unit.to_string_short());
+        s
+    }
+}
+
+// Choose the unit that fits the input value, so that the multiple does not exceed 8192.
+// The resulting size is a rounded value and might exceed u64::MAX bytes,
+// thus the return type is a plain value rather than the StorageSize struct.
+// e.g., 1023.5 KiB will be rounded to 1024 KiB, and 15.9 EiB will be rounded to 16 EiB.
+// 8192.5 KiB should be coverted to 8 MiB, not 8193 KiB, since the rounded value exceeds
+// the 8192 threshold.
+pub fn to_pretty_print_size(bytes: u64) -> (u64, Units) {
     use Units::*;
-    let units = [
+    const UNITS: [Units; 7] = [
         Byte, Kibibyte, Mebibyte, Gibibyte, Tebibyte, Pebibyte, Exbibyte,
     ];
 
-    // choose the unit that fits the input value
-    let mut val = bytes;
-    let mut i = 0;
-    while val > 8192 {
-        val = match val {
-            8193..=1048575 => (val as f64 / 1024.0).round() as u64,
-            _ => val / 1024,
-        };
+    // Choose the ith unit so that the initial multiple falls in the range [1024, 1048575] if
+    // possible.
+    let mut i = if bytes > 0 {
+        // (63 - leading_zeros) is the index of the highest non-zero bit
+        (63 - bytes.leading_zeros()) / 10
+    } else {
+        0
+    };
+    if i > 0 {
+        i -= 1;
+    }
+
+    let mut multiple = bytes >> (10 * i);
+    if multiple > 8192 {
+        multiple = (multiple as f64 / 1024.0).round() as u64;
         i += 1;
     }
 
-    (val, units[i])
+    (multiple, UNITS[i as usize])
+}
+
+//------------------------------------------
+
+#[cfg(test)]
+mod storage_size_tests {
+    use super::*;
+
+    #[test]
+    fn test_from_string() {
+        // default to sectors
+        assert_eq!(
+            StorageSize::from_str("1024").unwrap(),
+            StorageSize::sectors(1024).unwrap()
+        );
+        // bytes
+        assert_eq!(
+            StorageSize::from_str("1024b").unwrap(),
+            StorageSize::bytes(1024).unwrap()
+        );
+        // KiB
+        assert_eq!(
+            StorageSize::from_str("1024k").unwrap(),
+            StorageSize::kib(1024).unwrap()
+        );
+        // MiB
+        assert_eq!(
+            StorageSize::from_str("1024m").unwrap(),
+            StorageSize::mib(1024).unwrap()
+        );
+        // GiB
+        assert_eq!(
+            StorageSize::from_str("1024g").unwrap(),
+            StorageSize::gib(1024).unwrap()
+        );
+        // TiB
+        assert_eq!(
+            StorageSize::from_str("1024t").unwrap(),
+            StorageSize::tib(1024).unwrap()
+        );
+        // PiB
+        assert_eq!(
+            StorageSize::from_str("1024p").unwrap(),
+            StorageSize::pib(1024).unwrap()
+        );
+        // EiB
+        assert_eq!(
+            StorageSize::from_str("15e").unwrap(),
+            StorageSize::eib(15).unwrap()
+        );
+    }
+
+    #[test]
+    fn test_out_of_bounds() {
+        assert!(matches!(
+            StorageSize::from_str("18446744073709551616b"),
+            Err(_)
+        )); // bytes
+        assert!(matches!(StorageSize::from_str("36028797018963968"), Err(_))); // sectors
+        assert!(matches!(
+            StorageSize::from_str("18014398509481984k"),
+            Err(_)
+        )); // KiB
+        assert!(matches!(StorageSize::from_str("17592186044416m"), Err(_))); // MiB
+        assert!(matches!(StorageSize::from_str("17179869184g"), Err(_))); // GiB
+        assert!(matches!(StorageSize::from_str("16777216t"), Err(_))); // TiB
+        assert!(matches!(StorageSize::from_str("16384p"), Err(_))); // PiB
+        assert!(matches!(StorageSize::from_str("16e"), Err(_))); // EiB
+    }
+
+    #[test]
+    fn test_numeric_conversion() {
+        let orig = StorageSize::from_str("18446744073709551615b").unwrap();
+        let converted = StorageSize::bytes(orig.size_bytes()).unwrap();
+        assert_eq!(orig, converted);
+    }
+
+    #[test]
+    fn test_string_conversion() {
+        let orig = StorageSize::from_str("18446744073709551615b").unwrap();
+        let converted = StorageSize::from_str(&orig.to_string()).unwrap();
+        assert_eq!(orig, converted);
+    }
+
+    #[test]
+    fn test_pretty_print_max_multiples() {
+        assert_eq!(
+            to_pretty_print_size(8 * u64::pow(2, 10)),
+            (8192, Units::Byte)
+        );
+        assert_eq!(
+            to_pretty_print_size(8 * u64::pow(2, 20)),
+            (8192, Units::Kibibyte)
+        );
+        assert_eq!(
+            to_pretty_print_size(8 * u64::pow(2, 30)),
+            (8192, Units::Mebibyte)
+        );
+        assert_eq!(
+            to_pretty_print_size(8 * u64::pow(2, 40)),
+            (8192, Units::Gibibyte)
+        );
+        assert_eq!(
+            to_pretty_print_size(8 * u64::pow(2, 50)),
+            (8192, Units::Tebibyte)
+        );
+        assert_eq!(
+            to_pretty_print_size(8 * u64::pow(2, 60)),
+            (8192, Units::Pebibyte)
+        );
+    }
+
+    #[test]
+    fn test_pretty_print_min_multiples() {
+        assert_eq!(to_pretty_print_size(1), (1, Units::Byte));
+        // round down 8193 bytes to 8 KiB
+        assert_eq!(
+            to_pretty_print_size(8 * u64::pow(2, 10) + 1),
+            (8, Units::Kibibyte)
+        );
+        // round down 8192.001 KiB to 8 MiB
+        assert_eq!(
+            to_pretty_print_size(8 * u64::pow(2, 20) + u64::pow(2, 10)),
+            (8, Units::Mebibyte)
+        );
+        // round down 8192.001 MiB to 8 GiB
+        assert_eq!(
+            to_pretty_print_size(8 * u64::pow(2, 30) + u64::pow(2, 20)),
+            (8, Units::Gibibyte)
+        );
+        // round down 8192.001 GiB to 8 TiB
+        assert_eq!(
+            to_pretty_print_size(8 * u64::pow(2, 40) + u64::pow(2, 30)),
+            (8, Units::Tebibyte)
+        );
+        // round down 8192.001 TiB to 8 PiB
+        assert_eq!(
+            to_pretty_print_size(8 * u64::pow(2, 50) + u64::pow(2, 40)),
+            (8, Units::Pebibyte)
+        );
+        // round down 8192.001 PiB to 8 EiB
+        assert_eq!(
+            to_pretty_print_size(8 * u64::pow(2, 60) + u64::pow(2, 50)),
+            (8, Units::Exbibyte)
+        );
+    }
+
+    #[test]
+    fn test_pretty_print_min_max_bytes() {
+        assert_eq!(to_pretty_print_size(0), (0, Units::Byte));
+        assert_eq!(to_pretty_print_size(u64::MAX), (16, Units::Exbibyte));
+    }
+
+    #[test]
+    fn test_pretty_print_round_up() {
+        // round up 8.5 KiB to 9 KiB
+        assert_eq!(to_pretty_print_size(8 * 1024 + 512), (9, Units::Kibibyte));
+
+        // round up 1023.5 KiB to 1024 KiB
+        assert_eq!(
+            to_pretty_print_size(1023 * 1024 + 512),
+            (1024, Units::Kibibyte)
+        );
+    }
 }
 
 //------------------------------------------

--- a/tests/cache_metadata_size.rs
+++ b/tests/cache_metadata_size.rs
@@ -22,7 +22,9 @@ OPTIONS:
         --device-size <SIZE[bskmgtp]>    Specify total size of the fast device used in the cache
     -h, --help                           Print help information
         --max-hint-width <BYTES>         Specity the per-block hint width [default: 4]
+    -n, --numeric-only                   Output numeric value only
         --nr-blocks <NUM>                Specify the number of cache blocks
+    -u, --unit <UNIT>                    Specify the output unit in {bskKmMgG} [default: sector]
     -V, --version                        Print version information"
 );
 

--- a/tests/cache_metadata_size.rs
+++ b/tests/cache_metadata_size.rs
@@ -9,20 +9,22 @@ use common::target::*;
 
 //------------------------------------------
 
-const USAGE: &str = concat!("cache_metadata_size ",
-include_str!("../VERSION"),
-"Estimate the size of the metadata device needed for a given configuration.
+const USAGE: &str = concat!(
+    "cache_metadata_size ",
+    include_str!("../VERSION"),
+    "Estimate the size of the metadata device needed for a given configuration.
 
 USAGE:
-    cache_metadata_size [OPTIONS] <--device-size <SECTORS> --block-size <SECTORS> | --nr-blocks <NUM>>
+    cache_metadata_size [OPTIONS] <--device-size <SIZE> --block-size <SIZE> | --nr-blocks <NUM>>
 
 OPTIONS:
-        --block-size <SECTORS>      Specify the size of each cache block
-        --device-size <SECTORS>     Specify total size of the fast device used in the cache
-    -h, --help                      Print help information
-        --max-hint-width <BYTES>    Specity the per-block hint width [default: 4]
-        --nr-blocks <NUM>           Specify the number of cache blocks
-    -V, --version                   Print version information");
+        --block-size <SIZE[bskmg]>       Specify the size of each cache block
+        --device-size <SIZE[bskmgtp]>    Specify total size of the fast device used in the cache
+    -h, --help                           Print help information
+        --max-hint-width <BYTES>         Specity the per-block hint width [default: 4]
+        --nr-blocks <NUM>                Specify the number of cache blocks
+    -V, --version                        Print version information"
+);
 
 //------------------------------------------
 

--- a/tests/cache_metadata_size.rs
+++ b/tests/cache_metadata_size.rs
@@ -138,7 +138,7 @@ fn dev_size_and_nr_blocks_conflicts() -> Result<()> {
 fn block_size_and_nr_blocks_conflicts() -> Result<()> {
     run_fail(cache_metadata_size_cmd(args![
         "--block-size",
-        "100",
+        "64",
         "--nr-blocks",
         "1024"
     ]))?;
@@ -161,9 +161,9 @@ fn nr_blocks_alone() -> Result<()> {
 fn dev_size_and_block_size_succeeds() -> Result<()> {
     let out = run_ok_raw(cache_metadata_size_cmd(args![
         "--device-size",
-        "102400",
+        "65536",
         "--block-size",
-        "100"
+        "64"
     ]))?;
     let stdout = std::str::from_utf8(&out.stdout[..])
         .unwrap()
@@ -183,6 +183,36 @@ fn large_nr_blocks() -> Result<()> {
         .to_string();
     assert_eq!(stdout, "3678208 sectors");
     assert_eq!(out.stderr.len(), 0);
+    Ok(())
+}
+
+#[test]
+fn test_valid_block_sizes() -> Result<()> {
+    let block_sizes = [64, 128, 192, 2097152];
+    for bs in block_sizes {
+        let bs = bs.to_string();
+        run_ok(cache_metadata_size_cmd(args![
+            "--device-size",
+            "16777216",
+            "--block-size",
+            &bs
+        ]))?;
+    }
+    Ok(())
+}
+
+#[test]
+fn invalid_block_size_should_fail() -> Result<()> {
+    let block_sizes = [0, 32, 63, 2097153, 2097218, 4194304];
+    for bs in block_sizes {
+        let bs = bs.to_string();
+        run_fail(cache_metadata_size_cmd(args![
+            "--device-size",
+            "16777216",
+            "--block-size",
+            &bs
+        ]))?;
+    }
     Ok(())
 }
 

--- a/tests/common/target.rs
+++ b/tests/common/target.rs
@@ -108,6 +108,14 @@ where
     rust_cmd("thin_metadata_pack", args)
 }
 
+pub fn thin_metadata_size_cmd<I>(args: I) -> Command
+where
+    I: IntoIterator,
+    I::Item: Into<OsString>,
+{
+    rust_cmd("thin_metadata_size", args)
+}
+
 pub fn thin_metadata_unpack_cmd<I>(args: I) -> Command
 where
     I: IntoIterator,

--- a/tests/thin_metadata_size.rs
+++ b/tests/thin_metadata_size.rs
@@ -1,0 +1,160 @@
+use anyhow::Result;
+
+mod common;
+
+use common::common_args::*;
+use common::process::*;
+use common::program::*;
+use common::target::*;
+
+//------------------------------------------
+
+const USAGE: &str = concat!(
+    "thin_metadata_size ",
+    include_str!("../VERSION"),
+    "Estimate the size of the metadata device needed for a given configuration.
+
+USAGE:
+    thin_metadata_size [OPTIONS] --block-size <SIZE[bskmg]> --pool-size <SIZE[bskmgtp]> --max-thins <NUM>
+
+OPTIONS:
+    -b, --block-size <SIZE[bskmg]>     Specify the data block size
+    -h, --help                         Print help information
+    -m, --max-thins <NUM>              Maximum number of thin devices and snapshots
+    -n, --numeric-only                 Output numeric value only
+    -s, --pool-size <SIZE[bskmgtp]>    Specify the size of pool device
+    -u, --unit <UNIT>                  Specify the output unit in {bskKmMgG} [default: sector]
+    -V, --version                      Print version information"
+);
+
+//------------------------------------------
+
+struct ThinMetadataSize;
+
+impl<'a> Program<'a> for ThinMetadataSize {
+    fn name() -> &'a str {
+        "thin_metadata_size"
+    }
+
+    fn cmd<I>(args: I) -> Command
+    where
+        I: IntoIterator,
+        I::Item: Into<std::ffi::OsString>,
+    {
+        thin_metadata_size_cmd(args)
+    }
+
+    fn usage() -> &'a str {
+        USAGE
+    }
+
+    fn arg_type() -> ArgType {
+        ArgType::InputArg
+    }
+
+    fn bad_option_hint(option: &str) -> String {
+        msg::bad_option_hint(option)
+    }
+}
+
+//------------------------------------------
+
+test_accepts_help!(ThinMetadataSize);
+test_accepts_version!(ThinMetadataSize);
+test_rejects_bad_option!(ThinMetadataSize);
+
+//------------------------------------------
+
+#[test]
+fn no_args() -> Result<()> {
+    let _stderr = run_fail(thin_metadata_size_cmd([""; 0]))?;
+    Ok(())
+}
+
+#[test]
+fn missing_block_size_should_fail() -> Result<()> {
+    let _stderr = run_fail(thin_metadata_size_cmd(args![
+        "--pool-size",
+        "2097152",
+        "-m",
+        "1"
+    ]))?;
+    Ok(())
+}
+
+#[test]
+fn missing_pool_size_should_fail() -> Result<()> {
+    let _stderr = run_fail(thin_metadata_size_cmd(args![
+        "--block-size",
+        "128",
+        "-m",
+        "1"
+    ]))?;
+    Ok(())
+}
+
+#[test]
+fn missing_nr_thins_should_fail() -> Result<()> {
+    let _stderr = run_fail(thin_metadata_size_cmd(args![
+        "--pool-size",
+        "2097152",
+        "--block-size",
+        "128"
+    ]))?;
+    Ok(())
+}
+
+#[test]
+fn dev_size_and_block_size_succeeds() -> Result<()> {
+    let out = run_ok_raw(thin_metadata_size_cmd(args![
+        "--pool-size",
+        "2097152",
+        "--block-size",
+        "128",
+        "-m",
+        "1"
+    ]))?;
+    let stdout = std::str::from_utf8(&out.stdout[..])
+        .unwrap()
+        .trim_end_matches(|c| c == '\n' || c == '\r')
+        .to_string();
+    assert_eq!(stdout, "1056 sectors");
+    assert_eq!(out.stderr.len(), 0);
+    Ok(())
+}
+
+#[test]
+fn test_valid_block_sizes() -> Result<()> {
+    let block_sizes = [128, 256, 384, 2097152];
+    for bs in block_sizes {
+        let bs = bs.to_string();
+        run_ok(thin_metadata_size_cmd(args![
+            "--pool-size",
+            "16777216",
+            "--block-size",
+            &bs,
+            "-m",
+            "1"
+        ]))?;
+    }
+    Ok(())
+}
+
+#[test]
+fn invalid_block_size_should_fail() -> Result<()> {
+    let block_sizes = [0, 64, 127, 2097153, 2097280, 4194304];
+    for bs in block_sizes {
+        let bs = bs.to_string();
+        run_fail(thin_metadata_size_cmd(args![
+            "--pool-size",
+            "16777216",
+            "--block-size",
+            &bs,
+            "-m",
+            "1"
+        ]))?;
+    }
+    Ok(())
+}
+
+//------------------------------------------


### PR DESCRIPTION
- Support parsing unit prefixes
- Check input parameters
- Add --unit and --numeric-only options to cache_metadata_size