### PR TITLE
Various fixes

### DIFF
--- a/doc/TODO.md
+++ b/doc/TODO.md
@@ -20,6 +20,7 @@ Items in the High or Medium sections should be done before the formal release. T
 - [ ] btree_builder: Check pushed key ordering
 - [ ] thin/cache_metadata_size: Improve output precision (for Stratis)
 - [x] cache_restore: Support v1 metadata
+- [ ] Update man pages, e.g., limit the pool_size for thin_metadata_size to petabytes.
 
 ## Performance Issues
 
@@ -56,7 +57,7 @@ Items in the High or Medium sections should be done before the formal release. T
 
 - [ ] tests: Use packed metadata for all the programs incl. cache/era tools, to reduce coupling between tests
 - [ ] tests: Do not remove the test directory if an external program failed
-- [ ] thin_generate_fmetadata: Finish the metadata generator
+- [ ] thin_generate_metadata: Finish the metadata generator
 - [ ] btree_walker: Ensure visited nodes are counted (btree_walker with sm)
 - [ ] btree_builder: Verify ref counts of written nodes
 - [ ] cache_generate_damage to write an invalid superblock version (replaces `cache_restore --debug-override-metadata-version`)

--- a/src/cache/check.rs
+++ b/src/cache/check.rs
@@ -249,7 +249,7 @@ fn mk_context(opts: &CacheCheckOptions) -> anyhow::Result<Context> {
 }
 
 fn check_superblock(sb: &Superblock) -> anyhow::Result<()> {
-    if sb.version >= 2 && sb.dirty_root == None {
+    if sb.version >= 2 && sb.dirty_root.unwrap_or(0) == 0 {
         return Err(anyhow!("dirty bitset not found"));
     }
     Ok(())

--- a/src/cache/check.rs
+++ b/src/cache/check.rs
@@ -357,9 +357,13 @@ pub fn check(opts: CacheCheckOptions) -> anyhow::Result<()> {
         opts.ignore_non_fatal,
     )?;
 
-    if opts.auto_repair && !metadata_leaks.is_empty() {
-        ctx.report.info("Repairing metadata leaks.");
-        repair_space_map(ctx.engine.clone(), metadata_leaks, metadata_sm.clone())?;
+    if !metadata_leaks.is_empty() {
+        if opts.auto_repair {
+            ctx.report.info("Repairing metadata leaks.");
+            repair_space_map(ctx.engine.clone(), metadata_leaks, metadata_sm.clone())?;
+        } else if !opts.ignore_non_fatal {
+            return Err(anyhow!("metadata space map contains leaks"));
+        }
     }
 
     Ok(())

--- a/src/cache/metadata_size.rs
+++ b/src/cache/metadata_size.rs
@@ -1,5 +1,10 @@
 use anyhow::{anyhow, Result};
 
+use crate::io_engine::BLOCK_SIZE;
+use crate::pdata::space_map_metadata::MAX_METADATA_BLOCKS;
+
+//------------------------------------------
+
 const MIN_CACHE_BLOCK_SIZE: u64 = 32768;
 const MAX_CACHE_BLOCK_SIZE: u64 = 1073741824;
 
@@ -20,6 +25,7 @@ pub fn check_cache_block_size(block_size: u64) -> Result<()> {
     Ok(())
 }
 
+// Returns estimated size in bytes
 pub fn metadata_size(opts: &CacheMetadataSizeOptions) -> Result<u64> {
     const BYTES_PER_BLOCK_SHIFT: u64 = 4; // 16 bytes for key and value
     const TRANSACTION_OVERHEAD: u64 = 4 * 1024 * 1024; // 4 MB
@@ -28,5 +34,10 @@ pub fn metadata_size(opts: &CacheMetadataSizeOptions) -> Result<u64> {
     let mapping_size = opts.nr_blocks << BYTES_PER_BLOCK_SHIFT;
     let hint_size = opts.nr_blocks * (opts.max_hint_width as u64 + HINT_OVERHEAD_PER_BLOCK);
 
-    Ok(TRANSACTION_OVERHEAD + mapping_size + hint_size)
+    let mut size = TRANSACTION_OVERHEAD + mapping_size + hint_size;
+    size = std::cmp::min(size, (MAX_METADATA_BLOCKS * BLOCK_SIZE) as u64);
+
+    Ok(size)
 }
+
+//------------------------------------------

--- a/src/cache/metadata_size.rs
+++ b/src/cache/metadata_size.rs
@@ -1,7 +1,7 @@
 use anyhow::{anyhow, Result};
 
 use crate::io_engine::BLOCK_SIZE;
-use crate::pdata::space_map_metadata::MAX_METADATA_BLOCKS;
+use crate::pdata::space_map::metadata::MAX_METADATA_BLOCKS;
 
 //------------------------------------------
 

--- a/src/cache/superblock.rs
+++ b/src/cache/superblock.rs
@@ -91,13 +91,12 @@ fn unpack(data: &[u8]) -> IResult<&[u8], Superblock> {
     let (i, vsn_minor) = le_u32(i)?;
     let (i, vsn_patch) = le_u32(i)?;
 
-    let mut i = i;
-    let mut dirty_root = None;
-    if version >= 2 {
+    let (i, dirty_root) = if version >= 2 {
         let (m, root) = le_u64(i)?;
-        dirty_root = Some(root);
-        i = m;
-    }
+        (m, Some(root))
+    } else {
+        (i, None)
+    };
 
     Ok((
         i,

--- a/src/cache/writeback.rs
+++ b/src/cache/writeback.rs
@@ -568,7 +568,8 @@ pub fn writeback(opts: CacheWritebackOptions) -> anyhow::Result<()> {
             copy_dirty_blocks_async(&ctx, &sb, &opts)?
         } else {
             copy_dirty_blocks_sync(&ctx, &sb, &opts)?
-        }};
+        }
+    };
     report_stats(ctx.report.clone(), &stats);
 
     if corrupted {

--- a/src/commands/cache_check.rs
+++ b/src/commands/cache_check.rs
@@ -25,8 +25,13 @@ impl CacheCheckCommand {
             // flags
             .arg(
                 Arg::new("AUTO_REPAIR")
-                    .help("Auto repair trivial issues.")
+                    .help("Auto repair trivial issues")
                     .long("auto-repair"),
+            )
+            .arg(
+                Arg::new("CLEAR_NEEDS_CHECK")
+                    .help("Clears the 'needs_check' flag in the superblock")
+                    .long("clear-needs-check-flag"),
             )
             .arg(
                 Arg::new("IGNORE_NON_FATAL")
@@ -41,7 +46,7 @@ impl CacheCheckCommand {
             )
             .arg(
                 Arg::new("SB_ONLY")
-                    .help("Only check the superblock.")
+                    .help("Only check the superblock")
                     .long("super-block-only"),
             )
             .arg(
@@ -106,6 +111,7 @@ impl<'a> Command<'a> for CacheCheckCommand {
             skip_discards: matches.is_present("SKIP_DISCARDS"),
             ignore_non_fatal: matches.is_present("IGNORE_NON_FATAL"),
             auto_repair: matches.is_present("AUTO_REPAIR"),
+            clear_needs_check: matches.is_present("CLEAR_NEEDS_CHECK"),
             report: report.clone(),
         };
 

--- a/src/commands/cache_check.rs
+++ b/src/commands/cache_check.rs
@@ -66,7 +66,7 @@ impl CacheCheckCommand {
                     .required(true)
                     .index(1),
             );
-            engine_args(cmd)
+        engine_args(cmd)
     }
 }
 

--- a/src/commands/cache_dump.rs
+++ b/src/commands/cache_dump.rs
@@ -39,7 +39,7 @@ impl CacheDumpCommand {
                     .required(true)
                     .index(1),
             );
-            engine_args(cmd)
+        engine_args(cmd)
     }
 }
 

--- a/src/commands/cache_metadata_size.rs
+++ b/src/commands/cache_metadata_size.rs
@@ -129,13 +129,21 @@ impl<'a> Command<'a> for CacheMetadataSizeCommand {
         match metadata_size(&opts) {
             Ok(size) => {
                 let size = to_units(size, unit);
-                if numeric_only {
-                    println!("{}", size);
+
+                let mut output = if size < 1.0 || size.trunc() == size {
+                    format!("{}", size)
                 } else {
-                    let mut name = unit.to_string();
-                    name.push('s'); // plural form
-                    println!("{} {}", size, name);
+                    format!("{:.2}", size)
+                };
+
+                if !numeric_only {
+                    output.push(' ');
+                    output.push_str(&unit.to_string());
+                    output.push('s'); // plural form
                 }
+
+                println!("{}", output);
+
                 exitcode::OK
             }
             Err(reason) => {

--- a/src/commands/cache_repair.rs
+++ b/src/commands/cache_repair.rs
@@ -42,7 +42,7 @@ impl CacheRepairCommand {
                     .value_name("FILE")
                     .required(true),
             );
-            engine_args(cmd)
+        engine_args(cmd)
     }
 }
 

--- a/src/commands/cache_restore.rs
+++ b/src/commands/cache_restore.rs
@@ -47,7 +47,7 @@ impl CacheRestoreCommand {
                     .value_name("FILE")
                     .required(true),
             );
-            engine_args(cmd)
+        engine_args(cmd)
     }
 }
 

--- a/src/commands/cache_restore.rs
+++ b/src/commands/cache_restore.rs
@@ -18,9 +18,14 @@ impl CacheRestoreCommand {
             .about("Convert XML format metadata to binary.")
             .arg(
                 Arg::new("QUIET")
-                    .help("Suppress output messages, return only exit code.")
+                    .help("Suppress output messages, return only exit code")
                     .short('q')
                     .long("quiet"),
+            )
+            .arg(
+                Arg::new("OMIT_CLEAN_SHUTDOWN")
+                    .help("Don't set the clean shutdown flag")
+                    .long("omit-clean-shutdown"),
             )
             // options
             .arg(
@@ -77,6 +82,7 @@ impl<'a> Command<'a> for CacheRestoreCommand {
             metadata_version: matches.value_of_t_or_exit::<u8>("METADATA_VERSION"),
             engine_opts: engine_opts.unwrap(),
             report: report.clone(),
+            omit_clean_shutdown: matches.is_present("OMIT_CLEAN_SHUTDOWN"),
         };
 
         to_exit_code(&report, restore(opts))

--- a/src/commands/cache_writeback.rs
+++ b/src/commands/cache_writeback.rs
@@ -76,7 +76,7 @@ impl CacheWritebackCommand {
                     .long("buffer-size-meg")
                     .value_name("MB"),
             );
-            engine_args(cmd)
+        engine_args(cmd)
     }
 }
 

--- a/src/commands/era_check.rs
+++ b/src/commands/era_check.rs
@@ -46,7 +46,7 @@ impl EraCheckCommand {
                     .required(true)
                     .index(1),
             );
-            engine_args(cmd)
+        engine_args(cmd)
     }
 }
 

--- a/src/commands/era_invalidate.rs
+++ b/src/commands/era_invalidate.rs
@@ -45,7 +45,7 @@ impl EraInvalidateCommand {
                     .required(true)
                     .index(1),
             );
-            engine_args(cmd)
+        engine_args(cmd)
     }
 }
 

--- a/src/commands/era_restore.rs
+++ b/src/commands/era_restore.rs
@@ -40,7 +40,7 @@ impl EraRestoreCommand {
                     .value_name("FILE")
                     .required(true),
             );
-            engine_args(cmd)
+        engine_args(cmd)
     }
 }
 

--- a/src/commands/thin_check.rs
+++ b/src/commands/thin_check.rs
@@ -110,6 +110,7 @@ impl<'a> Command<'a> for ThinCheckCommand {
             ignore_non_fatal: matches.is_present("IGNORE_NON_FATAL"),
             auto_repair: matches.is_present("AUTO_REPAIR"),
             clear_needs_check: matches.is_present("CLEAR_NEEDS_CHECK"),
+            override_mapping_root: optional_value_or_exit::<u64>(&matches, "OVERRIDE_MAPPING_ROOT"),
             report: report.clone(),
         };
 

--- a/src/commands/thin_dump.rs
+++ b/src/commands/thin_dump.rs
@@ -82,7 +82,7 @@ impl ThinDumpCommand {
                     .required(true)
                     .index(1),
             );
-            engine_args(cmd)
+        engine_args(cmd)
     }
 }
 

--- a/src/commands/thin_generate_damage.rs
+++ b/src/commands/thin_generate_damage.rs
@@ -2,8 +2,8 @@ use clap::{Arg, ArgGroup};
 use std::path::Path;
 use std::process;
 
-use crate::commands::utils::*;
 use crate::commands::engine::*;
+use crate::commands::utils::*;
 use crate::thin::damage_generator::*;
 
 //------------------------------------------

--- a/src/commands/thin_ls.rs
+++ b/src/commands/thin_ls.rs
@@ -43,7 +43,7 @@ impl ThinLsCommand {
                     .required(true)
                     .index(1),
             );
-            engine_args(cmd)
+        engine_args(cmd)
     }
 }
 

--- a/src/commands/thin_metadata_size.rs
+++ b/src/commands/thin_metadata_size.rs
@@ -111,13 +111,21 @@ impl<'a> Command<'a> for ThinMetadataSizeCommand {
         match metadata_size(&opts) {
             Ok(size) => {
                 let size = to_units(size, unit);
-                if numeric_only {
-                    println!("{}", size);
+
+                let mut output = if size < 1.0 || size.trunc() == size {
+                    format!("{}", size)
                 } else {
-                    let mut name = unit.to_string();
-                    name.push('s'); // plural form
-                    println!("{} {}", size, name);
+                    format!("{:.2}", size)
+                };
+
+                if !numeric_only {
+                    output.push(' ');
+                    output.push_str(&unit.to_string());
+                    output.push('s'); // plural form
                 }
+
+                println!("{}", output);
+
                 exitcode::OK
             }
             Err(reason) => {

--- a/src/commands/thin_metadata_unpack.rs
+++ b/src/commands/thin_metadata_unpack.rs
@@ -33,7 +33,7 @@ impl ThinMetadataUnpackCommand {
                     .value_name("DEV")
                     .takes_value(true),
             );
-            engine_args(cmd)
+        engine_args(cmd)
     }
 }
 
@@ -51,7 +51,7 @@ impl<'a> Command<'a> for ThinMetadataUnpackCommand {
         let report = mk_simple_report();
         check_input_file(input_file, &report);
 
-	let report = std::sync::Arc::new(report);
+        let report = std::sync::Arc::new(report);
         to_exit_code(&report, unpack(input_file, output_file))
     }
 }

--- a/src/commands/thin_repair.rs
+++ b/src/commands/thin_repair.rs
@@ -58,7 +58,7 @@ impl ThinRepairCommand {
                     .long("transaction-id")
                     .value_name("NUM"),
             );
-            engine_args(cmd)
+        engine_args(cmd)
     }
 }
 

--- a/src/commands/thin_restore.rs
+++ b/src/commands/thin_restore.rs
@@ -58,7 +58,7 @@ impl ThinRestoreCommand {
                     .long("transaction-id")
                     .value_name("NUM"),
             );
-            engine_args(cmd)
+        engine_args(cmd)
     }
 }
 

--- a/src/commands/thin_rmap.rs
+++ b/src/commands/thin_rmap.rs
@@ -65,7 +65,7 @@ impl ThinRmapCommand {
                     .required(true)
                     .index(1),
             );
-            engine_args(cmd)
+        engine_args(cmd)
     }
 }
 

--- a/src/commands/thin_shrink.rs
+++ b/src/commands/thin_shrink.rs
@@ -11,8 +11,8 @@ use std::path::Path;
 
 use crate::commands::utils::*;
 use crate::commands::Command;
-use crate::shrink::toplevel::{shrink, ThinShrinkOptions};
 use crate::report::*;
+use crate::shrink::toplevel::{shrink, ThinShrinkOptions};
 
 pub struct ThinShrinkCommand;
 

--- a/src/commands/thin_trim.rs
+++ b/src/commands/thin_trim.rs
@@ -39,7 +39,7 @@ impl ThinTrimCommand {
                     .value_name("FILE")
                     .required(true),
             );
-            engine_args(cmd)
+        engine_args(cmd)
     }
 }
 

--- a/src/commands/utils.rs
+++ b/src/commands/utils.rs
@@ -96,14 +96,13 @@ pub fn to_exit_code<T>(report: &Arc<Report>, result: anyhow::Result<T>) -> exitc
     if let Err(e) = result {
         report.fatal(&format!("{}", e));
 
-/*
-                report.fatal(&format!("{:?}", e));
-                report.fatal(
-                    "metadata contains errors (run cache_check for details).\n\
-                    perhaps you wanted to run with --repair ?",
-                );
-                */
-
+        /*
+        report.fatal(&format!("{:?}", e));
+        report.fatal(
+            "metadata contains errors (run cache_check for details).\n\
+            perhaps you wanted to run with --repair ?",
+        );
+        */
 
         // FIXME: we need a way of getting more meaningful error codes
         exitcode::USAGE

--- a/src/io_engine/base.rs
+++ b/src/io_engine/base.rs
@@ -43,6 +43,7 @@ impl Block {
         }
     }
 
+    #[allow(clippy::missing_safety_doc)]
     pub unsafe fn get_raw_ptr(&self) -> *mut u8 {
         self.data
     }

--- a/src/io_engine/core.rs
+++ b/src/io_engine/core.rs
@@ -49,7 +49,6 @@ impl IoEngine for CoreIoEngine {
         1
     }
 
-
     fn suggest_nr_threads(&self) -> usize {
         1
     }

--- a/src/io_engine/mod.rs
+++ b/src/io_engine/mod.rs
@@ -14,5 +14,3 @@ pub use crate::io_engine::async_::AsyncIoEngine;
 
 #[cfg(test)]
 pub mod core;
-
-

--- a/src/io_engine/sync.rs
+++ b/src/io_engine/sync.rs
@@ -1,10 +1,8 @@
 use std::fs::File;
 use std::fs::OpenOptions;
 use std::io::Result;
-use std::ops::{Deref, DerefMut};
 use std::os::unix::fs::{FileExt, OpenOptionsExt};
 use std::path::Path;
-use std::sync::{Condvar, Mutex};
 
 use crate::io_engine::*;
 
@@ -12,47 +10,7 @@ use crate::io_engine::*;
 
 pub struct SyncIoEngine {
     nr_blocks: u64,
-    files: Mutex<Vec<File>>,
-    cvar: Condvar,
-}
-
-struct FileGuard<'a> {
-    engine: &'a SyncIoEngine,
-    file: Option<File>,
-}
-
-impl<'a> FileGuard<'a> {
-    fn new(engine: &'a SyncIoEngine, file: File) -> Self {
-        FileGuard {
-            engine,
-            file: Some(file),
-        }
-    }
-}
-
-impl<'a> Deref for FileGuard<'a> {
-    type Target = File;
-
-    fn deref(&self) -> &File {
-        self.file.as_ref().expect("empty file guard")
-    }
-}
-
-impl<'a> DerefMut for FileGuard<'a> {
-    fn deref_mut(&mut self) -> &mut File {
-        match &mut self.file {
-            None => {
-                panic!("empty file guard")
-            }
-            Some(f) => f,
-        }
-    }
-}
-
-impl<'a> Drop for FileGuard<'a> {
-    fn drop(&mut self) {
-        self.engine.put(self.file.take().expect("empty file guard"));
-    }
+    file: File,
 }
 
 impl SyncIoEngine {
@@ -75,47 +33,10 @@ impl SyncIoEngine {
     }
 
     pub fn new_with<P: AsRef<Path>>(path: P, writable: bool, excl: bool) -> Result<Self> {
-        let nr_files = 8;
         let nr_blocks = get_nr_blocks(path.as_ref())?; // check file mode before opening it
-        let mut files = Vec::with_capacity(nr_files);
         let file = SyncIoEngine::open_file(path.as_ref(), writable, excl)?;
-        for _n in 0..nr_files - 1 {
-            files.push(file.try_clone()?);
-        }
-        files.push(file);
 
-        Ok(SyncIoEngine {
-            nr_blocks,
-            files: Mutex::new(files),
-            cvar: Condvar::new(),
-        })
-    }
-
-    fn get(&self) -> FileGuard {
-        let mut files = self.files.lock().unwrap();
-
-        while files.len() == 0 {
-            files = self.cvar.wait(files).unwrap();
-        }
-
-        FileGuard::new(self, files.pop().unwrap())
-    }
-
-    fn put(&self, f: File) {
-        let mut files = self.files.lock().unwrap();
-        files.push(f);
-        self.cvar.notify_one();
-    }
-
-    fn read_(input: &mut File, loc: u64) -> Result<Block> {
-        let b = Block::new(loc);
-        input.read_exact_at(b.get_data(), b.loc * BLOCK_SIZE as u64)?;
-        Ok(b)
-    }
-
-    fn write_(output: &mut File, b: &Block) -> Result<()> {
-        output.write_all_at(b.get_data(), b.loc * BLOCK_SIZE as u64)?;
-        Ok(())
+        Ok(SyncIoEngine { nr_blocks, file })
     }
 }
 
@@ -133,27 +54,30 @@ impl IoEngine for SyncIoEngine {
     }
 
     fn read(&self, loc: u64) -> Result<Block> {
-        SyncIoEngine::read_(&mut self.get(), loc)
+        let b = Block::new(loc);
+        self.file
+            .read_exact_at(b.get_data(), b.loc * BLOCK_SIZE as u64)?;
+        Ok(b)
     }
 
     fn read_many(&self, blocks: &[u64]) -> Result<Vec<Result<Block>>> {
-        let mut input = self.get();
         let mut bs = Vec::new();
         for b in blocks {
-            bs.push(SyncIoEngine::read_(&mut input, *b));
+            bs.push(self.read(*b));
         }
         Ok(bs)
     }
 
     fn write(&self, b: &Block) -> Result<()> {
-        SyncIoEngine::write_(&mut self.get(), b)
+        self.file
+            .write_all_at(b.get_data(), b.loc * BLOCK_SIZE as u64)?;
+        Ok(())
     }
 
     fn write_many(&self, blocks: &[Block]) -> Result<Vec<Result<()>>> {
-        let mut output = self.get();
         let mut bs = Vec::new();
         for b in blocks {
-            bs.push(SyncIoEngine::write_(&mut output, b));
+            bs.push(self.write(b));
         }
         Ok(bs)
     }

--- a/src/pdata/space_map/checker.rs
+++ b/src/pdata/space_map/checker.rs
@@ -6,9 +6,9 @@ use crate::checksum;
 use crate::io_engine::IoEngine;
 use crate::pdata::btree::{self, *};
 use crate::pdata::btree_walker::*;
-use crate::pdata::space_map::*;
 use crate::pdata::space_map::common::*;
 use crate::pdata::space_map::metadata::*;
+use crate::pdata::space_map::*;
 use crate::pdata::unpack::*;
 use crate::report::Report;
 

--- a/src/pdata/space_map/disk.rs
+++ b/src/pdata/space_map/disk.rs
@@ -1,8 +1,8 @@
 use anyhow::Result;
 
 use crate::pdata::btree_builder::*;
-use crate::pdata::space_map::*;
 use crate::pdata::space_map::common::*;
+use crate::pdata::space_map::*;
 use crate::write_batcher::*;
 
 //------------------------------------------

--- a/src/pdata/space_map/metadata.rs
+++ b/src/pdata/space_map/metadata.rs
@@ -6,8 +6,8 @@ use std::sync::{Arc, Mutex};
 
 use crate::checksum;
 use crate::io_engine::*;
-use crate::pdata::space_map::*;
 use crate::pdata::space_map::common::*;
+use crate::pdata::space_map::*;
 use crate::pdata::unpack::*;
 use crate::write_batcher::*;
 

--- a/src/pdata/space_map/metadata.rs
+++ b/src/pdata/space_map/metadata.rs
@@ -14,7 +14,7 @@ use crate::write_batcher::*;
 //------------------------------------------
 
 const MAX_METADATA_BITMAPS: usize = 255;
-const MAX_METADATA_BLOCKS: usize = MAX_METADATA_BITMAPS * ENTRIES_PER_BITMAP;
+pub const MAX_METADATA_BLOCKS: usize = MAX_METADATA_BITMAPS * ENTRIES_PER_BITMAP;
 
 //------------------------------------------
 

--- a/src/thin/check.rs
+++ b/src/thin/check.rs
@@ -81,8 +81,6 @@ fn inc_superblock(sm: &ASpaceMap) -> Result<()> {
 
 //------------------------------------------
 
-pub const MAX_CONCURRENT_IO: u32 = 1024;
-
 pub struct ThinCheckOptions<'a> {
     pub input: &'a Path,
     pub engine_opts: EngineOptions,

--- a/src/thin/delta.rs
+++ b/src/thin/delta.rs
@@ -299,7 +299,9 @@ struct Context {
 }
 
 fn mk_context(opts: &ThinDeltaOptions) -> Result<Context> {
-    let engine = EngineBuilder::new(opts.input, &opts.engine_opts).exclusive(!opts.engine_opts.use_metadata_snap).build()?;
+    let engine = EngineBuilder::new(opts.input, &opts.engine_opts)
+        .exclusive(!opts.engine_opts.use_metadata_snap)
+        .build()?;
 
     Ok(Context {
         engine,

--- a/src/units.rs
+++ b/src/units.rs
@@ -219,13 +219,10 @@ pub fn to_pretty_print_size(bytes: u64) -> (u64, Units) {
     // possible.
     let mut i = if bytes > 0 {
         // (63 - leading_zeros) is the index of the highest non-zero bit
-        (63 - bytes.leading_zeros()) / 10
+        ((63 - bytes.leading_zeros()) / 10).saturating_sub(1)
     } else {
         0
     };
-    if i > 0 {
-        i -= 1;
-    }
 
     let mut multiple = bytes >> (10 * i);
     if multiple > 8192 {

--- a/tests/cache_check.rs
+++ b/tests/cache_check.rs
@@ -191,6 +191,29 @@ fn incompat_metadata_version_v2() -> Result<()> {
     Ok(())
 }
 
+#[test]
+fn dirty_bitset_not_found_should_fail() -> Result<()> {
+    let mut td = TestDir::new()?;
+    let md = mk_zeroed_md(&mut td)?;
+    run_ok(cache_generate_metadata_cmd(args![
+        "-o",
+        &md,
+        "--format",
+        "--metadata-version",
+        "1",
+        "--percent-dirty",
+        "0"
+    ]))?;
+    run_ok(cache_generate_metadata_cmd(args![
+        "-o",
+        &md,
+        "--set-superblock-version",
+        "2"
+    ]))?;
+    run_fail(cache_check_cmd(args![&md]))?;
+    Ok(())
+}
+
 //------------------------------------------
 // test clear-needs-check
 

--- a/tests/cache_check.rs
+++ b/tests/cache_check.rs
@@ -135,28 +135,57 @@ fn valid_metadata_passes() -> Result<()> {
     Ok(())
 }
 
-// FIXME: put back in, I don't want to add the --debug- arg to the
-// tool again, so we should have a little library function for tweaking
-// metadata version.
-
-/*
 #[test]
 fn bad_metadata_version() -> Result<()> {
     let mut td = TestDir::new()?;
     let xml = mk_valid_xml(&mut td)?;
     let md = mk_zeroed_md(&mut td)?;
-    run_ok(
-        cache_restore_cmd(
-        args![
-            "-i",
-            &xml,
-            "-o",
-            &md,
-            "--debug-override-metadata-version",
-            "12345"
-        ],
-    ))?;
+    run_ok(cache_restore_cmd(args!["-i", &xml, "-o", &md]))?;
+    run_ok(cache_generate_metadata_cmd(args![
+        "-o",
+        &md,
+        "--set-superblock-version",
+        "3"
+    ]))?;
     run_fail(cache_check_cmd(args![&md]))?;
     Ok(())
 }
-*/
+
+#[test]
+fn incompat_metadata_version_v1() -> Result<()> {
+    let mut td = TestDir::new()?;
+    let xml = mk_valid_xml(&mut td)?;
+    let md = mk_zeroed_md(&mut td)?;
+    run_ok(cache_restore_cmd(args!["-i", &xml, "-o", &md]))?;
+    run_ok(cache_generate_metadata_cmd(args![
+        "-o",
+        &md,
+        "--set-superblock-version",
+        "1"
+    ]))?;
+    run_fail(cache_check_cmd(args![&md]))?;
+    Ok(())
+}
+
+#[test]
+fn incompat_metadata_version_v2() -> Result<()> {
+    let mut td = TestDir::new()?;
+    let xml = mk_valid_xml(&mut td)?;
+    let md = mk_zeroed_md(&mut td)?;
+    run_ok(cache_restore_cmd(args![
+        "-i",
+        &xml,
+        "-o",
+        &md,
+        "--metadata-version",
+        "1"
+    ]))?;
+    run_ok(cache_generate_metadata_cmd(args![
+        "-o",
+        &md,
+        "--set-superblock-version",
+        "2"
+    ]))?;
+    run_fail(cache_check_cmd(args![&md]))?;
+    Ok(())
+}

--- a/tests/cache_restore.rs
+++ b/tests/cache_restore.rs
@@ -28,7 +28,8 @@ OPTIONS:
         --metadata-version <NUM>    Specify the output metadata version [default: 2] [possible
                                     values: 1, 2]
     -o, --output <FILE>             Specify the output device
-    -q, --quiet                     Suppress output messages, return only exit code.
+        --omit-clean-shutdown       Don't set the clean shutdown flag
+    -q, --quiet                     Suppress output messages, return only exit code
     -V, --version                   Print version information"
 );
 
@@ -165,19 +166,20 @@ fn override_metadata_version() -> Result<()> {
 }
 */
 
-// FIXME: finish
-/*
 #[test]
-fn accepts_omit_clean_shutdown() -> Result<()> {
+fn omit_clean_shutdown() -> Result<()> {
     let mut td = TestDir::new()?;
     let xml = mk_valid_xml(&mut td)?;
     let md = mk_zeroed_md(&mut td)?;
-    run_ok(
-        cache_restore_cmd(
-        args!["-i", &xml, "-o", &md, "--omit-clean-shutdown"],
-    ))?;
+    run_ok(cache_restore_cmd(args![
+        "-i",
+        &xml,
+        "-o",
+        &md,
+        "--omit-clean-shutdown"
+    ]))?;
+    assert!(!get_clean_shutdown(&md)?);
     Ok(())
 }
-*/
 
 //-----------------------------------------

--- a/tests/common/cache.rs
+++ b/tests/common/cache.rs
@@ -43,4 +43,18 @@ pub fn get_clean_shutdown(md: &Path) -> Result<bool> {
     Ok(sb.flags.clean_shutdown)
 }
 
+pub fn get_needs_check(md: &Path) -> Result<bool> {
+    use thinp::cache::superblock::*;
+
+    let engine = SyncIoEngine::new(md, false)?;
+    let sb = read_superblock(&engine, SUPERBLOCK_LOCATION)?;
+    Ok(sb.flags.needs_check)
+}
+
+pub fn set_needs_check(md: &Path) -> Result<()> {
+    let args = args!["-o", &md, "--set-needs-check"];
+    run_ok(cache_generate_metadata_cmd(args))?;
+    Ok(())
+}
+
 //-----------------------------------------------

--- a/tests/common/cache.rs
+++ b/tests/common/cache.rs
@@ -1,7 +1,9 @@
 use anyhow::Result;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use thinp::cache::metadata_generator::CacheGenerator;
 use thinp::file_utils;
+
+use thinp::io_engine::SyncIoEngine;
 
 use crate::args;
 use crate::common::cache_xml_generator::write_xml;
@@ -29,6 +31,16 @@ pub fn mk_valid_md(td: &mut TestDir) -> Result<PathBuf> {
     run_ok(cache_restore_cmd(args!["-i", &xml, "-o", &md]))?;
 
     Ok(md)
+}
+
+//-----------------------------------------------
+
+pub fn get_clean_shutdown(md: &Path) -> Result<bool> {
+    use thinp::cache::superblock::*;
+
+    let engine = SyncIoEngine::new(md, false)?;
+    let sb = read_superblock(&engine, SUPERBLOCK_LOCATION)?;
+    Ok(sb.flags.clean_shutdown)
 }
 
 //-----------------------------------------------

--- a/tests/common/target.rs
+++ b/tests/common/target.rs
@@ -148,6 +148,14 @@ where
     rust_cmd("cache_dump", args)
 }
 
+pub fn cache_generate_metadata_cmd<I>(args: I) -> Command
+where
+    I: IntoIterator,
+    I::Item: Into<OsString>,
+{
+    rust_devel_cmd("cache_generate_metadata", args)
+}
+
 pub fn cache_metadata_size_cmd<I>(args: I) -> Command
 where
     I: IntoIterator,

--- a/tests/thin_metadata_size.rs
+++ b/tests/thin_metadata_size.rs
@@ -118,7 +118,7 @@ fn dev_size_and_block_size_succeeds() -> Result<()> {
         .unwrap()
         .trim_end_matches(|c| c == '\n' || c == '\r')
         .to_string();
-    assert_eq!(stdout, "1056 sectors");
+    assert_eq!(stdout, "1064 sectors");
     assert_eq!(out.stderr.len(), 0);
     Ok(())
 }


### PR DESCRIPTION
- cache_check: Captures leaked blocks errors; added --clear-needs-check-flag
- thin_check: Add --override-mapping-root
- cache_restore: Add --omit-clean-shutdown for tests
- Tidy up thin/cache_metadata_size, and limit the maximum output value
- Test features for metadata generator