### PR TITLE
Improve error handling of cache_writeback

### DIFF
--- a/src/cache/writeback.rs
+++ b/src/cache/writeback.rs
@@ -309,7 +309,7 @@ impl CopyOpBatcher_ {
     }
 
     /// Send the current batch and return the dirty ablocks bitmap.
-    fn complete(&mut self) -> anyhow::Result<()> {
+    fn complete(mut self) -> anyhow::Result<()> {
         self.send_ops()?;
         Ok(())
     }
@@ -333,7 +333,7 @@ impl CopyOpBatcher {
     }
 
     fn complete(self) -> anyhow::Result<()> {
-        let mut inner = self.inner.lock().unwrap();
+        let inner = self.inner.into_inner().unwrap();
         inner.complete()
     }
 }

--- a/src/cache/writeback.rs
+++ b/src/cache/writeback.rs
@@ -14,7 +14,7 @@ use crate::checksum;
 use crate::commands::engine::*;
 use crate::io_engine::copier::*;
 use crate::io_engine::sync_copier::*;
-use crate::io_engine::utils::VectoredBlockIo;
+use crate::io_engine::utils::{SimpleBlockIo, VectoredBlockIo};
 use crate::io_engine::{self, *};
 use crate::pdata::array::{self, *};
 use crate::pdata::array_walker::*;
@@ -35,7 +35,7 @@ struct WritebackStats {
     /// Number of read errors
     nr_read_errors: u64,
 
-    // Number of write errors
+    /// Number of write errors
     nr_write_errors: u64,
 }
 
@@ -79,7 +79,7 @@ impl ProgressReporter {
     }
 
     /// Accessor for the current stats
-    fn stats(&self) -> WritebackStats {
+    fn _stats(&self) -> WritebackStats {
         let inner = self.inner.lock().unwrap();
         (*inner).clone()
     }
@@ -609,17 +609,66 @@ fn copy_dirty_blocks(
     sb: &Superblock,
     opts: &CacheWritebackOptions,
 ) -> anyhow::Result<(WritebackStats, RoaringBitmap)> {
+    ctx.report.set_title("Copying cache blocks");
     let block_size = sb.data_block_size * 512;
+    let fast_dev_offset = opts.fast_dev_offset.unwrap_or(0) * 512;
+    let origin_dev_offset = opts.origin_dev_offset.unwrap_or(0) * 512;
 
-    // Prepare the copier
-    let mut copier = SyncCopier::<VectoredBlockIo<File>>::from_path(
-        opts.buffer_size.unwrap_or(128 * 1024) * 512,
-        block_size as usize,
-        opts.fast_dev,
-        opts.origin_dev,
-    )?
-    .src_offset(opts.fast_dev_offset.unwrap_or(0) * 512)?
-    .dest_offset(opts.origin_dev_offset.unwrap_or(0) * 512)?;
+    // Copy all the dirty blocks
+    let (nr_blocks, mut cleaned, mut read_failed, mut write_failed) = {
+        let copier = Box::new(
+            SyncCopier::<VectoredBlockIo<File>>::from_path(
+                opts.buffer_size.unwrap_or(128 * 1024) * 512,
+                block_size as usize,
+                opts.fast_dev,
+                opts.origin_dev,
+            )?
+            .src_offset(fast_dev_offset)?
+            .dest_offset(origin_dev_offset)?,
+        );
+
+        copy_all_dirty_blocks(ctx.engine.clone(), sb, copier, ctx.report.clone())?
+    };
+
+    // Retry blocks ignoed by vectored io
+    if !read_failed.is_empty() || !write_failed.is_empty() {
+        let copier = Box::new(
+            SyncCopier::<SimpleBlockIo<File>>::from_path(
+                opts.buffer_size.unwrap_or(128 * 1024) * 512,
+                block_size as usize,
+                opts.fast_dev,
+                opts.origin_dev,
+            )?
+            .src_offset(fast_dev_offset)?
+            .dest_offset(origin_dev_offset)?,
+        );
+
+        let failed = &read_failed | &write_failed;
+        let c;
+        (c, read_failed, write_failed) =
+            copy_selected_blocks(ctx.engine.clone(), sb, copier, &failed, ctx.report.clone())?;
+        cleaned |= c;
+    }
+
+    let stats = WritebackStats {
+        nr_blocks: nr_blocks as u64,
+        nr_copied: cleaned.len(),
+        nr_read_errors: read_failed.len(),
+        nr_write_errors: write_failed.len(),
+    };
+
+    Ok((stats, cleaned))
+}
+
+fn copy_all_dirty_blocks(
+    engine: Arc<dyn IoEngine + Send + Sync>,
+    sb: &Superblock,
+    mut copier: Box<dyn Copier + Send>,
+    report: Arc<Report>,
+) -> anyhow::Result<(u32, RoaringBitmap, RoaringBitmap, RoaringBitmap)> {
+    let selector = mk_selector(engine.clone(), sb)?;
+    let nr_blocks = selector.get_nr_to_writeback();
+    let progress = Arc::new(ProgressReporter::new(report, nr_blocks as u64));
 
     // We pass work to the copy thread via a sync channel with a limit
     // of a single entry, this allows us to prepare one vector of copy ops
@@ -627,13 +676,11 @@ fn copy_dirty_blocks(
     let (tx, rx) = mpsc::sync_channel::<Vec<CopyOp>>(1);
 
     // launch the copy thread
-    let selector = mk_selector(ctx.engine.clone(), sb)?;
-    let nr_blocks = selector.get_nr_to_writeback();
-    let progress = Arc::new(ProgressReporter::new(ctx.report.clone(), nr_blocks as u64));
     let copy_thread = {
-        let progress = progress.clone();
         thread::spawn(move || {
             let mut cleaned = RoaringBitmap::new();
+            let mut read_failed = RoaringBitmap::new();
+            let mut write_failed = RoaringBitmap::new();
 
             while let Ok(ops) = rx.recv() {
                 {
@@ -650,30 +697,105 @@ fn copy_dirty_blocks(
                 {
                     for op in stats.read_errors {
                         cleaned.remove(op.src as u32);
+                        read_failed.insert(op.src as u32);
                     }
 
                     for op in stats.write_errors {
                         cleaned.remove(op.src as u32);
+                        write_failed.insert(op.src as u32);
                     }
                 }
             }
 
-            cleaned
+            (cleaned, read_failed, write_failed)
         })
     };
 
     // Build batches of copy operations and pass them to the copy thread
-    ctx.report.set_title("Copying cache blocks");
     let batcher = CopyOpBatcher::new(1_000_000, tx, selector);
-    let w = ArrayWalker::new(ctx.engine.clone(), true);
+    let w = ArrayWalker::new(engine, true);
 
     // FIXME: do something with this
     let _walk_err = w.walk(&batcher, sb.mapping_root);
 
     batcher.complete()?;
-    let cleaned = copy_thread.join().unwrap();
+    let (cleaned, read_failed, write_failed) = copy_thread.join().unwrap();
 
-    Ok((progress.stats(), cleaned))
+    Ok((nr_blocks, cleaned, read_failed, write_failed))
+}
+
+fn copy_selected_blocks(
+    engine: Arc<dyn IoEngine + Send + Sync>,
+    sb: &Superblock,
+    mut copier: Box<dyn Copier + Send>,
+    blocks: &RoaringBitmap,
+    report: Arc<Report>,
+) -> anyhow::Result<(RoaringBitmap, RoaringBitmap, RoaringBitmap)> {
+    let (tx, rx) = mpsc::sync_channel::<Vec<CopyOp>>(1);
+    let progress = Arc::new(ProgressReporter::new(report, blocks.len() as u64));
+
+    let copy_thread = {
+        thread::spawn(move || {
+            let mut cleaned = RoaringBitmap::new();
+            let mut read_failed = RoaringBitmap::new();
+            let mut write_failed = RoaringBitmap::new();
+
+            while let Ok(ops) = rx.recv() {
+                {
+                    // We assume the copies will succeed, and then remove
+                    // entries that failed afterwards.
+                    for op in &ops {
+                        cleaned.insert(op.src as u32);
+                    }
+                }
+
+                let stats = copier.copy(&ops, progress.clone()).expect("copy failed");
+                progress.inc_stats(&stats);
+
+                {
+                    for op in stats.read_errors {
+                        cleaned.remove(op.src as u32);
+                        read_failed.insert(op.src as u32);
+                    }
+
+                    for op in stats.write_errors {
+                        cleaned.remove(op.src as u32);
+                        write_failed.insert(op.src as u32);
+                    }
+                }
+            }
+
+            (cleaned, read_failed, write_failed)
+        })
+    };
+
+    let mut batcher = CopyOpBatcher_::new(1_000_000, tx);
+
+    let ablocks = btree_to_value_vec::<u64>(&mut vec![0], engine.clone(), true, sb.mapping_root)?;
+    let entries_per_block = array::calc_max_entries::<Mapping>();
+    let mut index = 0;
+    let b = engine.read(ablocks[index])?;
+    let mut ablock = unpack_array_block::<Mapping>(&[ablocks[index]], b.get_data())?;
+    for cblock in blocks.iter() {
+        if cblock as usize / entries_per_block != index {
+            index = cblock as usize / entries_per_block;
+            let b = engine.read(ablocks[index])?;
+            ablock = unpack_array_block::<Mapping>(&[ablocks[index]], b.get_data())?;
+        }
+
+        let m = ablock.values[cblock as usize % entries_per_block];
+        let op = CopyOp {
+            src: cblock as u64,
+            dst: m.oblock,
+        };
+
+        batcher.push(op)?;
+    }
+
+    batcher.complete()?;
+    let (cleaned, read_failed, write_failed) = copy_thread.join().unwrap();
+
+    Ok((cleaned, read_failed, write_failed))
 }
 
 fn report_stats(report: Arc<Report>, stats: &WritebackStats) {

--- a/src/commands/cache_writeback.rs
+++ b/src/commands/cache_writeback.rs
@@ -75,6 +75,13 @@ impl CacheWritebackCommand {
                     .help("Specify the size for the data cache, in megabytes")
                     .long("buffer-size-meg")
                     .value_name("MB"),
+            )
+            .arg(
+                Arg::new("RETRY_COUNT")
+                    .help("Specify how many times to retry data copying on failed data block")
+                    .long("retry-count")
+                    .value_name("CNT")
+                    .default_value("0"),
             );
         engine_args(cmd)
     }
@@ -120,6 +127,7 @@ impl<'a> Command<'a> for CacheWritebackCommand {
                 .map(|v| v * 2048),
             list_failed_blocks: matches.is_present("LIST_FAILED_BLOCKS"),
             update_metadata: !matches.is_present("NO_METADATA_UPDATE"),
+            retry_count: matches.value_of_t_or_exit::<u32>("RETRY_COUNT"),
             report: report.clone(),
         };
 

--- a/src/io_engine/copier.rs
+++ b/src/io_engine/copier.rs
@@ -6,7 +6,7 @@ use std::sync::Arc;
 
 pub type Block = u64;
 
-#[derive(Copy, Clone, Debug)]
+#[derive(Copy, Clone, Debug, PartialEq)]
 pub struct CopyOp {
     pub src: Block,
     pub dst: Block,

--- a/src/io_engine/mod.rs
+++ b/src/io_engine/mod.rs
@@ -22,3 +22,6 @@ pub mod core;
 
 #[cfg(test)]
 pub mod ramdisk;
+
+#[cfg(any(test, feature = "devtools"))]
+pub mod test_utils;

--- a/src/io_engine/mod.rs
+++ b/src/io_engine/mod.rs
@@ -1,6 +1,7 @@
 pub mod base;
 pub mod buffer;
 pub mod copier;
+pub mod rescue_copier;
 pub mod spindle;
 pub mod sync;
 pub mod sync_copier;

--- a/src/io_engine/mod.rs
+++ b/src/io_engine/mod.rs
@@ -18,3 +18,6 @@ pub use crate::io_engine::async_::AsyncIoEngine;
 
 #[cfg(test)]
 pub mod core;
+
+#[cfg(test)]
+pub mod ramdisk;

--- a/src/io_engine/ramdisk.rs
+++ b/src/io_engine/ramdisk.rs
@@ -1,0 +1,145 @@
+use roaring::RoaringBitmap;
+use std::io;
+use std::ops::Range;
+use std::os::unix::fs::FileExt;
+use std::sync::{Arc, Mutex};
+
+use crate::io_engine::base::{PAGE_SHIFT, PAGE_SIZE};
+use crate::io_engine::buffer::Buffer;
+use crate::io_engine::VectoredIo;
+use crate::math::div_up;
+
+//------------------------------------------
+
+/// A mock ramdisk that simulates direct io behaviors and also supports
+/// error injection.
+/// If there's any broken sector within the range to read or write, then
+/// the entire io should fail.
+pub struct Ramdisk {
+    data: Arc<Buffer>,
+    invalid_pages: Arc<Mutex<RoaringBitmap>>,
+}
+
+impl Ramdisk {
+    pub fn new(size_bytes: u32) -> Self {
+        let data = Arc::new(Buffer::new(size_bytes as usize, 4096));
+        let invalid_pages = Arc::new(Mutex::new(RoaringBitmap::new()));
+        Self {
+            data,
+            invalid_pages,
+        }
+    }
+
+    pub fn try_clone(&self) -> io::Result<Ramdisk> {
+        Ok(Self {
+            data: self.data.clone(),
+            invalid_pages: self.invalid_pages.clone(),
+        })
+    }
+
+    pub fn invalidate(&mut self, bytes: Range<u32>) {
+        let page_begin = bytes.start >> PAGE_SHIFT;
+        let page_end = div_up(bytes.end, PAGE_SIZE as u32);
+        let mut invalid_pages = self.invalid_pages.lock().unwrap();
+
+        for i in page_begin..page_end {
+            invalid_pages.insert(i);
+        }
+    }
+
+    fn is_valid_range(invalid_pages: &RoaringBitmap, bytes: Range<u32>) -> bool {
+        let page_begin = bytes.start >> PAGE_SHIFT;
+        let page_end = div_up(bytes.end, PAGE_SIZE as u32);
+
+        for i in page_begin..page_end {
+            if invalid_pages.contains(i) {
+                return false;
+            }
+        }
+        true
+    }
+}
+
+impl VectoredIo for Ramdisk {
+    fn read_vectored_at(&self, bufs: &mut [libc::iovec], pos: u64) -> io::Result<usize> {
+        let invalid_pages = self.invalid_pages.lock().unwrap();
+
+        let mut begin = pos as u32;
+        for buf in bufs {
+            if buf.iov_len & (PAGE_SIZE - 1) != 0 {
+                return Err(io::Error::from(io::ErrorKind::InvalidInput));
+            }
+
+            if !Self::is_valid_range(&invalid_pages, begin..begin + buf.iov_len as u32) {
+                return Err(io::Error::new(io::ErrorKind::Other, "read error"));
+            }
+
+            unsafe {
+                std::ptr::copy(
+                    self.data.get_data()[begin as usize..].as_ptr(),
+                    buf.iov_base as *mut u8,
+                    buf.iov_len,
+                );
+            }
+
+            begin += buf.iov_len as u32;
+        }
+        Ok(begin as usize - pos as usize)
+    }
+
+    fn write_vectored_at(&self, bufs: &[libc::iovec], pos: u64) -> io::Result<usize> {
+        let invalid_pages = self.invalid_pages.lock().unwrap();
+
+        let mut begin = pos as u32;
+        for buf in bufs {
+            if buf.iov_len & (PAGE_SIZE - 1) != 0 {
+                return Err(io::Error::from(io::ErrorKind::InvalidInput));
+            }
+
+            if !Self::is_valid_range(&invalid_pages, begin..begin + buf.iov_len as u32) {
+                return Err(io::Error::new(io::ErrorKind::Other, "write error"));
+            }
+
+            unsafe {
+                std::ptr::copy(
+                    buf.iov_base as *const u8,
+                    self.data.get_data()[begin as usize..].as_mut_ptr(),
+                    buf.iov_len,
+                );
+            }
+
+            begin += buf.iov_len as u32;
+        }
+        Ok(begin as usize - pos as usize)
+    }
+}
+
+impl FileExt for Ramdisk {
+    fn read_at(&self, buf: &mut [u8], offset: u64) -> io::Result<usize> {
+        let invalid_pages = self.invalid_pages.lock().unwrap();
+        if !Self::is_valid_range(
+            &invalid_pages,
+            offset as u32..offset as u32 + buf.len() as u32,
+        ) {
+            return Err(io::Error::new(io::ErrorKind::Other, "read error"));
+        }
+        buf.clone_from_slice(&self.data.get_data()[offset as usize..(offset as usize + buf.len())]);
+
+        Ok(buf.len())
+    }
+
+    fn write_at(&self, buf: &[u8], offset: u64) -> io::Result<usize> {
+        let invalid_pages = self.invalid_pages.lock().unwrap();
+        if !Self::is_valid_range(
+            &invalid_pages,
+            offset as u32..offset as u32 + buf.len() as u32,
+        ) {
+            return Err(io::Error::new(io::ErrorKind::Other, "write error"));
+        }
+        self.data.get_data()[offset as usize..offset as usize + buf.len()].clone_from_slice(buf);
+
+        Ok(buf.len())
+    }
+}
+
+//------------------------------------------

--- a/src/io_engine/rescue_copier.rs
+++ b/src/io_engine/rescue_copier.rs
@@ -1,0 +1,148 @@
+use anyhow::{anyhow, Result};
+use fixedbitset::FixedBitSet;
+use std::fs::{File, OpenOptions};
+use std::os::unix::fs::FileExt;
+use std::os::unix::fs::OpenOptionsExt;
+use std::path::Path;
+use std::sync::atomic::Ordering;
+use std::sync::Arc;
+
+use crate::io_engine::buffer::*;
+use crate::io_engine::copier::*;
+use crate::io_engine::{is_page_aligned, PAGE_SHIFT, PAGE_SIZE};
+
+//-------------------------------------
+
+pub struct RescueCopier<T: FileExt> {
+    block_size: usize,
+    src: T,
+    src_offset: u64,
+    dst: T,
+    dst_offset: u64,
+    buf: Buffer,
+    read_success: FixedBitSet,
+}
+
+impl<T: FileExt> RescueCopier<T> {
+    pub fn new(block_size: usize, src: T, dst: T) -> Result<RescueCopier<T>> {
+        // must be a multiple of page size since we'll copy the blocks page-by-page.
+        if !is_page_aligned(block_size as u64) {
+            return Err(anyhow!("block size must be page aligned"));
+        }
+
+        let buf = Buffer::new(block_size, 4096);
+        let read_success = FixedBitSet::with_capacity(block_size >> PAGE_SHIFT);
+
+        Ok(Self {
+            block_size,
+            src,
+            src_offset: 0,
+            dst,
+            dst_offset: 0,
+            buf,
+            read_success,
+        })
+    }
+
+    pub fn from_path<P: AsRef<Path>>(
+        block_size: usize,
+        src: P,
+        dst: P,
+    ) -> Result<RescueCopier<File>> {
+        let src_file = OpenOptions::new()
+            .read(true)
+            .custom_flags(libc::O_EXCL | libc::O_DIRECT)
+            .open(src)?;
+
+        let dst_file = OpenOptions::new()
+            .read(false)
+            .write(true)
+            .custom_flags(libc::O_EXCL | libc::O_DIRECT)
+            .open(dst)?;
+
+        RescueCopier::<File>::new(block_size, src_file, dst_file)
+    }
+
+    pub fn src_offset(mut self, offset: u64) -> Result<RescueCopier<T>> {
+        if !is_page_aligned(offset) {
+            return Err(anyhow!("offset must be page aligned"));
+        }
+        self.src_offset = offset;
+        Ok(self)
+    }
+
+    pub fn dest_offset(mut self, offset: u64) -> Result<RescueCopier<T>> {
+        if !is_page_aligned(offset) {
+            return Err(anyhow!("offset must be page aligned"));
+        }
+        self.dst_offset = offset;
+        Ok(self)
+    }
+
+    fn do_read(src: &T, pos: u64, buffer: &mut [u8], read_success: &mut FixedBitSet) -> usize {
+        let mut read_fails = 0;
+        for (i, chunk) in buffer.chunks_mut(PAGE_SIZE).enumerate() {
+            let p = pos + (i << PAGE_SHIFT) as u64;
+            if src.read_exact_at(chunk, p).is_ok() {
+                read_success.insert(i);
+            } else {
+                read_fails += 1;
+            }
+        }
+        read_fails
+    }
+
+    fn do_write(dst: &T, pos: u64, buffer: &mut [u8], selected_pages: &FixedBitSet) -> u32 {
+        let mut write_fails = 0;
+        for i in selected_pages.ones() {
+            let offset = i << PAGE_SHIFT;
+            let page_buf = &buffer[offset..offset + PAGE_SIZE];
+            if dst.write_all_at(page_buf, pos + offset as u64).is_err() {
+                write_fails += 1;
+            }
+        }
+        write_fails
+    }
+}
+
+impl<T: FileExt + 'static> Copier for RescueCopier<T> {
+    fn copy(
+        &mut self,
+        ops: &[CopyOp],
+        progress: Arc<dyn CopyProgress + Sync + Send>,
+    ) -> Result<CopyStats> {
+        let mut stats = CopyStats::new(ops.len() as u64);
+        let mut nr_copied = 0;
+
+        // copy loop
+        for op in ops {
+            self.read_success.clear();
+
+            let pos = self.src_offset + op.src * self.block_size as u64;
+            let read_fails =
+                Self::do_read(&self.src, pos, self.buf.get_data(), &mut self.read_success);
+            if read_fails > 0 {
+                stats.read_errors.push(*op);
+            }
+
+            let pos = self.dst_offset + op.dst * self.block_size as u64;
+            let write_fails =
+                Self::do_write(&self.dst, pos, self.buf.get_data(), &self.read_success);
+            if write_fails > 0 {
+                stats.write_errors.push(*op);
+                continue;
+            }
+
+            if read_fails == 0 && write_fails == 0 {
+                nr_copied += 1;
+            }
+        }
+
+        stats.nr_copied.fetch_add(nr_copied, Ordering::SeqCst);
+        progress.update(&stats);
+
+        Ok(stats)
+    }
+}
+
+//-------------------------------------

--- a/src/io_engine/rescue_copier.rs
+++ b/src/io_engine/rescue_copier.rs
@@ -11,6 +11,9 @@ use crate::io_engine::buffer::*;
 use crate::io_engine::copier::*;
 use crate::io_engine::{is_page_aligned, PAGE_SHIFT, PAGE_SIZE};
 
+#[cfg(test)]
+mod tests;
+
 //-------------------------------------
 
 pub struct RescueCopier<T: FileExt> {

--- a/src/io_engine/rescue_copier/tests.rs
+++ b/src/io_engine/rescue_copier/tests.rs
@@ -1,0 +1,307 @@
+use super::*;
+use rand::prelude::*;
+use rand::Rng;
+use roaring::RoaringBitmap;
+use std::collections::BTreeMap;
+use std::ops::Range;
+use std::os::unix::fs::FileExt;
+
+use crate::io_engine::base::PAGE_SIZE;
+use crate::io_engine::ramdisk::Ramdisk;
+use crate::io_engine::test_utils::*;
+use crate::math::div_up;
+use crate::random::Generator;
+
+//------------------------------------------
+
+const SRC_SALT: u64 = 0x6b8b16c70a82b5b5;
+const BLOCK_SIZE: u32 = 32768; // 32 KiB
+
+fn mk_random_ops(src: Range<u64>, dst: Range<u64>, nr_ops: usize) -> Vec<CopyOp> {
+    let mut src_blocks: Vec<u64> = src.into_iter().collect();
+    let mut dst_blocks: Vec<u64> = dst.into_iter().collect();
+
+    src_blocks.shuffle(&mut rand::thread_rng());
+    dst_blocks.shuffle(&mut rand::thread_rng());
+
+    src_blocks
+        .into_iter()
+        .take(nr_ops)
+        .zip(dst_blocks.into_iter())
+        .map(|(src, dst)| CopyOp { src, dst })
+        .collect()
+}
+
+//------------------------------------------
+
+trait SourcePageIndicator {
+    fn source(&self, page: u64) -> Option<u64>;
+}
+
+struct CopySourceIndicator {
+    rmap: BTreeMap<u64, u64>, // rmap of blocks
+    pages_per_block: usize,
+}
+
+impl CopySourceIndicator {
+    fn new(rmap: BTreeMap<u64, u64>, pages_per_block: usize) -> Self {
+        Self {
+            rmap,
+            pages_per_block,
+        }
+    }
+}
+
+impl SourcePageIndicator for CopySourceIndicator {
+    fn source(&self, page: u64) -> Option<u64> {
+        let block = page / self.pages_per_block as u64;
+        let page_off = page % self.pages_per_block as u64;
+        self.rmap
+            .get(&block)
+            .map(|src| src * self.pages_per_block as u64 + page_off)
+    }
+}
+
+//------------------------------------------
+
+// page-based verifier
+struct CopyVerifier {
+    dev: Ramdisk,
+    seed: u64,
+    indicator: Box<dyn SourcePageIndicator>,
+    buf: Buffer,
+    faulty_src_pages: RoaringBitmap,
+    faulty_dst_pages: RoaringBitmap,
+}
+
+impl CopyVerifier {
+    fn new(dev: Ramdisk, seed: u64, indicator: Box<dyn SourcePageIndicator>) -> Self {
+        let buf = Buffer::new(PAGE_SIZE, PAGE_SIZE);
+
+        Self {
+            dev,
+            seed,
+            indicator,
+            buf,
+            faulty_src_pages: RoaringBitmap::new(),
+            faulty_dst_pages: RoaringBitmap::new(),
+        }
+    }
+}
+
+impl BlockVisitor for CopyVerifier {
+    fn visit(&mut self, page: u64) -> Result<()> {
+        if self.faulty_dst_pages.contains(page as u32) {
+            return Ok(()); // skip unwritable blocks
+        }
+
+        let seed = match self.indicator.source(page) {
+            Some(src) => {
+                if self.faulty_src_pages.contains(src as u32) {
+                    // pages with unreadable sources should not be touched
+                    self.seed ^ page
+                } else {
+                    self.seed ^ src ^ SRC_SALT
+                }
+            }
+            None => self.seed ^ page,
+        };
+
+        let offset = page << PAGE_SHIFT;
+        self.dev.read_exact_at(self.buf.get_data(), offset)?;
+
+        let mut gen = Generator::new();
+        if !gen.verify_buffer(seed, self.buf.get_data())? {
+            return Err(anyhow!("data verification failed for page {}", page));
+        }
+
+        Ok(())
+    }
+}
+
+//------------------------------------------
+
+struct CopierTest {
+    src: Ramdisk,
+    dst: Ramdisk,
+    block_size: usize,
+    nr_src_blocks: u64,
+    nr_dst_blocks: u64,
+    seed: u64,
+    faulty_src_pages: RoaringBitmap,
+    faulty_dst_pages: RoaringBitmap,
+}
+
+impl CopierTest {
+    fn new(block_size: u32, nr_src_blocks: u32, nr_dst_blocks: u32) -> Self {
+        let src = Ramdisk::new(block_size * nr_src_blocks);
+        let dst = Ramdisk::new(block_size * nr_dst_blocks);
+
+        Self {
+            src,
+            dst,
+            block_size: block_size as usize,
+            nr_src_blocks: nr_src_blocks as u64,
+            nr_dst_blocks: nr_dst_blocks as u64,
+            seed: rand::thread_rng().gen::<u64>(),
+            faulty_src_pages: RoaringBitmap::new(),
+            faulty_dst_pages: RoaringBitmap::new(),
+        }
+    }
+
+    fn stamp_src_dev(&self) -> Result<()> {
+        let src = self.src.try_clone()?;
+        let pages_per_block = self.block_size >> PAGE_SHIFT;
+        let mut stamper = Stamper::new(src, self.seed ^ SRC_SALT, PAGE_SIZE);
+        visit_blocks(self.nr_src_blocks * pages_per_block as u64, &mut stamper)
+    }
+
+    fn stamp_dst_dev(&self) -> Result<()> {
+        let dst = self.dst.try_clone()?;
+        let pages_per_block = self.block_size >> PAGE_SHIFT;
+        let mut stamper = Stamper::new(dst, self.seed, PAGE_SIZE);
+        visit_blocks(self.nr_dst_blocks * pages_per_block as u64, &mut stamper)
+    }
+
+    fn invalidate_src_dev(&mut self, bytes: Range<u32>) -> Result<()> {
+        let page_begin = bytes.start >> PAGE_SHIFT;
+        let page_end = div_up(bytes.end, PAGE_SIZE as u32);
+
+        self.src.invalidate(bytes);
+
+        for p in page_begin..page_end {
+            self.faulty_src_pages.push(p);
+        }
+
+        Ok(())
+    }
+
+    fn invalidate_dst_dev(&mut self, bytes: Range<u32>) -> Result<()> {
+        let page_begin = bytes.start >> PAGE_SHIFT;
+        let page_end = div_up(bytes.end, PAGE_SIZE as u32);
+
+        self.dst.invalidate(bytes);
+
+        for p in page_begin..page_end {
+            self.faulty_dst_pages.push(p);
+        }
+
+        Ok(())
+    }
+
+    fn verify(&self, ops: &[CopyOp]) -> Result<()> {
+        let rmap: BTreeMap<u64, u64> = ops.iter().map(|op| (op.dst, op.src)).collect();
+        let pages_per_block = self.block_size >> PAGE_SHIFT;
+        let indicator = Box::new(CopySourceIndicator::new(rmap, pages_per_block));
+
+        let dst = self.dst.try_clone()?;
+        let mut verifier = CopyVerifier::new(dst, self.seed, indicator);
+        verifier.faulty_src_pages = self.faulty_src_pages.clone();
+        verifier.faulty_dst_pages = self.faulty_dst_pages.clone();
+        visit_blocks(self.nr_dst_blocks * pages_per_block as u64, &mut verifier)
+    }
+
+    fn copy(&self, ops: &[CopyOp]) -> Result<CopyStats> {
+        let mut copier = RescueCopier::<Ramdisk>::new(
+            self.block_size,
+            self.src.try_clone().unwrap(),
+            self.dst.try_clone().unwrap(),
+        )
+        .unwrap();
+
+        let progress = Arc::new(IgnoreProgress {});
+        copier.copy(ops, progress)
+    }
+}
+
+//------------------------------------------
+
+#[test]
+fn copy_completed_blocks() -> Result<()> {
+    const NR_BLOCKS: u64 = 1024;
+    let t = CopierTest::new(BLOCK_SIZE, NR_BLOCKS as u32, NR_BLOCKS as u32);
+    t.stamp_src_dev()?;
+    t.stamp_dst_dev()?;
+
+    let ops = mk_random_ops(0..NR_BLOCKS, 0..NR_BLOCKS, NR_BLOCKS as usize);
+    let stats = t.copy(&ops).unwrap();
+    assert_eq!(stats.nr_blocks, ops.len() as u64);
+    assert_eq!(stats.nr_copied.load(Ordering::Relaxed), ops.len() as u64);
+    assert!(stats.read_errors.is_empty());
+    assert!(stats.write_errors.is_empty());
+
+    t.verify(&ops)
+}
+
+#[test]
+fn partial_copy_with_unreadable_pages() -> Result<()> {
+    const NR_BLOCKS: u64 = 1024;
+    let mut t = CopierTest::new(BLOCK_SIZE, NR_BLOCKS as u32, NR_BLOCKS as u32);
+    t.stamp_src_dev()?;
+    t.stamp_dst_dev()?;
+    t.invalidate_src_dev(65536..69632)?;
+
+    let ops = mk_random_ops(0..NR_BLOCKS, 0..NR_BLOCKS, NR_BLOCKS as usize);
+    let stats = t.copy(&ops).unwrap();
+    assert_eq!(stats.nr_blocks, ops.len() as u64);
+    assert_eq!(
+        stats.nr_copied.load(Ordering::Relaxed),
+        ops.len() as u64 - 1
+    );
+    assert_eq!(stats.read_errors.len(), 1);
+    assert!(stats.write_errors.is_empty());
+
+    assert_eq!(stats.read_errors[0].src, 2);
+
+    t.verify(&ops)
+}
+
+#[test]
+fn partial_copy_with_unwritable_pages() -> Result<()> {
+    const NR_BLOCKS: u64 = 1024;
+    let mut t = CopierTest::new(BLOCK_SIZE, NR_BLOCKS as u32, NR_BLOCKS as u32);
+    t.stamp_src_dev()?;
+    t.stamp_dst_dev()?;
+    t.invalidate_dst_dev(32768..36882)?;
+
+    let ops = mk_random_ops(0..NR_BLOCKS, 0..NR_BLOCKS, NR_BLOCKS as usize);
+    let stats = t.copy(&ops).unwrap();
+    assert_eq!(stats.nr_blocks, ops.len() as u64);
+    assert_eq!(
+        stats.nr_copied.load(Ordering::Relaxed),
+        ops.len() as u64 - 1
+    );
+    assert!(stats.read_errors.is_empty());
+    assert_eq!(stats.write_errors.len(), 1);
+
+    assert_eq!(stats.write_errors[0].dst, 1);
+
+    t.verify(&ops)
+}
+
+#[test]
+fn partial_copy_with_unreadable_and_unwritable_pages() -> Result<()> {
+    const NR_BLOCKS: u64 = 1024;
+    let mut t = CopierTest::new(BLOCK_SIZE, NR_BLOCKS as u32, NR_BLOCKS as u32);
+    t.stamp_src_dev()?;
+    t.stamp_dst_dev()?;
+    t.invalidate_src_dev(65536..69632)?;
+    t.invalidate_dst_dev(32768..36882)?;
+
+    let ops = mk_random_ops(0..NR_BLOCKS, 0..NR_BLOCKS, NR_BLOCKS as usize);
+    let stats = t.copy(&ops).unwrap();
+    assert_eq!(stats.nr_blocks, ops.len() as u64);
+    assert_eq!(
+        stats.nr_copied.load(Ordering::Relaxed),
+        ops.len() as u64 - 2
+    );
+    assert_eq!(stats.read_errors.len(), 1);
+    assert_eq!(stats.write_errors.len(), 1);
+
+    assert_eq!(stats.read_errors[0].src, 2);
+    assert_eq!(stats.write_errors[0].dst, 1);
+
+    t.verify(&ops)
+}
+
+//------------------------------------------

--- a/src/io_engine/sync_copier.rs
+++ b/src/io_engine/sync_copier.rs
@@ -14,6 +14,9 @@ use crate::io_engine::copier::*;
 use crate::io_engine::is_page_aligned;
 use crate::io_engine::utils::*;
 
+#[cfg(test)]
+mod tests;
+
 //-------------------------------------
 
 pub struct SyncCopier<T: ReadBlocks + WriteBlocks + Send> {

--- a/src/io_engine/sync_copier/tests.rs
+++ b/src/io_engine/sync_copier/tests.rs
@@ -1,0 +1,439 @@
+use super::*;
+use rand::prelude::*;
+use rand::Rng;
+use std::collections::BTreeMap;
+use std::ops::Range;
+use std::os::unix::fs::FileExt;
+
+use crate::io_engine::base::PAGE_SIZE;
+use crate::io_engine::ramdisk::Ramdisk;
+use crate::io_engine::test_utils::*;
+use crate::math::div_up;
+use crate::random::Generator;
+
+//------------------------------------------
+
+const SRC_SALT: u64 = 0x6b8b16c70a82b5b5;
+const BUFFER_SIZE: usize = 16777216; // 16 MiB
+const BLOCK_SIZE: u32 = 32768; // 32 KiB
+
+fn mk_ops<T1: IntoIterator<Item = u64>, T2: IntoIterator<Item = u64>>(
+    src_seq: T1,
+    dst_seq: T2,
+) -> Vec<CopyOp> {
+    src_seq
+        .into_iter()
+        .zip(dst_seq.into_iter())
+        .map(|(src, dst)| CopyOp { src, dst })
+        .collect()
+}
+
+fn mk_random_ops(src: Range<u64>, dst: Range<u64>, nr_ops: usize) -> Vec<CopyOp> {
+    let mut src_blocks: Vec<u64> = src.into_iter().collect();
+    let mut dst_blocks: Vec<u64> = dst.into_iter().collect();
+
+    src_blocks.shuffle(&mut rand::thread_rng());
+    dst_blocks.shuffle(&mut rand::thread_rng());
+
+    src_blocks
+        .into_iter()
+        .take(nr_ops)
+        .zip(dst_blocks.into_iter())
+        .map(|(src, dst)| CopyOp { src, dst })
+        .collect()
+}
+
+//------------------------------------------
+
+trait SourceBlockIndicator {
+    fn source(&self, block: u64) -> Option<u64>;
+}
+
+struct CopySourceIndicator {
+    rmap: BTreeMap<u64, u64>,
+}
+
+impl CopySourceIndicator {
+    fn new(rmap: BTreeMap<u64, u64>) -> Self {
+        Self { rmap }
+    }
+}
+
+impl SourceBlockIndicator for CopySourceIndicator {
+    fn source(&self, block: u64) -> Option<u64> {
+        self.rmap.get(&block).copied()
+    }
+}
+
+//------------------------------------------
+
+struct CopyVerifier {
+    dev: Ramdisk,
+    block_size: usize,
+    seed: u64,
+    indicator: Box<dyn SourceBlockIndicator>,
+    buf: Buffer,
+    faulty_src_blocks: RoaringBitmap,
+    faulty_dst_blocks: RoaringBitmap,
+}
+
+impl CopyVerifier {
+    fn new(
+        dev: Ramdisk,
+        block_size: usize,
+        seed: u64,
+        indicator: Box<dyn SourceBlockIndicator>,
+    ) -> Self {
+        let buf = Buffer::new(block_size, PAGE_SIZE);
+
+        Self {
+            dev,
+            block_size,
+            seed,
+            indicator,
+            buf,
+            faulty_src_blocks: RoaringBitmap::new(),
+            faulty_dst_blocks: RoaringBitmap::new(),
+        }
+    }
+}
+
+impl BlockVisitor for CopyVerifier {
+    fn visit(&mut self, block: u64) -> Result<()> {
+        if self.faulty_dst_blocks.contains(block as u32) {
+            return Ok(()); // skip unwritable blocks
+        }
+
+        let seed = match self.indicator.source(block) {
+            Some(src) => {
+                if self.faulty_src_blocks.contains(src as u32) {
+                    // blocks with unreadable sources should not be touched
+                    self.seed ^ block
+                } else {
+                    self.seed ^ src ^ SRC_SALT
+                }
+            }
+            None => self.seed ^ block,
+        };
+
+        let offset = block * self.block_size as u64;
+        self.dev.read_exact_at(self.buf.get_data(), offset)?;
+
+        let mut gen = Generator::new();
+        if !gen.verify_buffer(seed, self.buf.get_data())? {
+            return Err(anyhow!("data verification failed for block {}", block));
+        }
+
+        Ok(())
+    }
+}
+
+//------------------------------------------
+
+struct CopierTest {
+    src: Ramdisk,
+    dst: Ramdisk,
+    block_size: usize,
+    nr_src_blocks: u64,
+    nr_dst_blocks: u64,
+    seed: u64,
+    faulty_src_blocks: RoaringBitmap,
+    faulty_dst_blocks: RoaringBitmap,
+}
+
+impl CopierTest {
+    fn new(block_size: u32, nr_src_blocks: u32, nr_dst_blocks: u32) -> Self {
+        let src = Ramdisk::new(block_size * nr_src_blocks);
+        let dst = Ramdisk::new(block_size * nr_dst_blocks);
+
+        Self {
+            src,
+            dst,
+            block_size: block_size as usize,
+            nr_src_blocks: nr_src_blocks as u64,
+            nr_dst_blocks: nr_dst_blocks as u64,
+            seed: rand::thread_rng().gen::<u64>(),
+            faulty_src_blocks: RoaringBitmap::new(),
+            faulty_dst_blocks: RoaringBitmap::new(),
+        }
+    }
+
+    fn stamp_src_dev(&self) -> Result<()> {
+        let src = self.src.try_clone()?;
+        let mut stamper = Stamper::new(src, self.seed ^ SRC_SALT, self.block_size);
+        visit_blocks(self.nr_src_blocks, &mut stamper)
+    }
+
+    fn stamp_dst_dev(&self) -> Result<()> {
+        let dst = self.dst.try_clone()?;
+        let mut stamper = Stamper::new(dst, self.seed, self.block_size);
+        visit_blocks(self.nr_dst_blocks, &mut stamper)
+    }
+
+    fn invalidate_src_dev(&mut self, bytes: Range<u32>) -> Result<()> {
+        let block_begin = bytes.start / self.block_size as u32;
+        let block_end = div_up(bytes.end, self.block_size as u32);
+
+        self.src.invalidate(bytes);
+
+        for b in block_begin..block_end {
+            self.faulty_src_blocks.push(b);
+        }
+
+        Ok(())
+    }
+
+    fn invalidate_dst_dev(&mut self, bytes: Range<u32>) -> Result<()> {
+        let block_begin = bytes.start / self.block_size as u32;
+        let block_end = div_up(bytes.end, self.block_size as u32);
+
+        self.dst.invalidate(bytes);
+
+        for b in block_begin..block_end {
+            self.faulty_dst_blocks.push(b);
+        }
+
+        Ok(())
+    }
+
+    fn verify(&self, ops: &[CopyOp]) -> Result<()> {
+        let rmap: BTreeMap<u64, u64> = ops.iter().map(|op| (op.dst, op.src)).collect();
+        let indicator = Box::new(CopySourceIndicator::new(rmap));
+
+        let dst = self.dst.try_clone()?;
+        let mut verifier = CopyVerifier::new(dst, self.block_size, self.seed, indicator);
+        verifier.faulty_src_blocks = self.faulty_src_blocks.clone();
+        verifier.faulty_dst_blocks = self.faulty_dst_blocks.clone();
+        visit_blocks(self.nr_dst_blocks, &mut verifier)
+    }
+
+    fn copy(&self, ops: &[CopyOp], buffer_size: usize) -> Result<CopyStats> {
+        let mut copier = SyncCopier::<SimpleBlockIo<Ramdisk>>::new(
+            buffer_size,
+            self.block_size,
+            self.src.try_clone().unwrap().into(),
+            self.dst.try_clone().unwrap().into(),
+        )
+        .unwrap();
+
+        let progress = Arc::new(IgnoreProgress {});
+        copier.copy(ops, progress)
+    }
+}
+
+//------------------------------------------
+
+// mirroring a device greater than the buffer size
+#[test]
+fn mirroring() -> Result<()> {
+    const NR_BLOCKS: u64 = 1024;
+
+    let t = CopierTest::new(BLOCK_SIZE, NR_BLOCKS as u32, NR_BLOCKS as u32);
+    t.stamp_src_dev()?;
+    t.stamp_dst_dev()?;
+
+    let ops = mk_ops(0..NR_BLOCKS, 0..NR_BLOCKS);
+    let stats = t.copy(&ops, BUFFER_SIZE).unwrap();
+    assert_eq!(stats.nr_blocks, ops.len() as u64);
+    assert_eq!(stats.nr_copied.load(Ordering::Relaxed), ops.len() as u64);
+    assert!(stats.read_errors.is_empty());
+    assert!(stats.write_errors.is_empty());
+
+    t.verify(&ops)?;
+
+    Ok(())
+}
+
+#[test]
+fn copy_with_ops_sorted_by_src() -> Result<()> {
+    const NR_BLOCKS: u64 = 1024;
+
+    let t = CopierTest::new(BLOCK_SIZE, NR_BLOCKS as u32, NR_BLOCKS as u32);
+    t.stamp_src_dev()?;
+    t.stamp_dst_dev()?;
+
+    let ops = mk_ops(0..NR_BLOCKS, (0..NR_BLOCKS).rev());
+    let stats = t.copy(&ops, BUFFER_SIZE).unwrap();
+    assert_eq!(stats.nr_blocks, NR_BLOCKS);
+    assert_eq!(stats.nr_copied.load(Ordering::Relaxed), NR_BLOCKS);
+    assert!(stats.read_errors.is_empty());
+    assert!(stats.write_errors.is_empty());
+
+    t.verify(&ops)?;
+
+    Ok(())
+}
+
+#[test]
+fn copy_with_ops_sorted_by_dst() -> Result<()> {
+    const NR_BLOCKS: u64 = 1024;
+
+    let t = CopierTest::new(BLOCK_SIZE, NR_BLOCKS as u32, NR_BLOCKS as u32);
+    t.stamp_src_dev()?;
+    t.stamp_dst_dev()?;
+
+    let ops = mk_ops((0..NR_BLOCKS).rev(), 0..NR_BLOCKS);
+    let stats = t.copy(&ops, BUFFER_SIZE).unwrap();
+    assert_eq!(stats.nr_blocks, ops.len() as u64);
+    assert_eq!(stats.nr_copied.load(Ordering::Relaxed), ops.len() as u64);
+    assert!(stats.read_errors.is_empty());
+    assert!(stats.write_errors.is_empty());
+
+    t.verify(&ops)
+}
+
+#[test]
+fn copy_randomly() -> Result<()> {
+    const NR_BLOCKS: u64 = 1024;
+
+    let t = CopierTest::new(BLOCK_SIZE, NR_BLOCKS as u32, NR_BLOCKS as u32);
+    t.stamp_src_dev()?;
+    t.stamp_dst_dev()?;
+
+    let nr_ops = (NR_BLOCKS / 2) as usize;
+    let ops = mk_random_ops(0..NR_BLOCKS, 0..NR_BLOCKS, nr_ops);
+    let stats = t.copy(&ops, BUFFER_SIZE).unwrap();
+    assert_eq!(stats.nr_blocks, ops.len() as u64);
+    assert_eq!(stats.nr_copied.load(Ordering::Relaxed), ops.len() as u64);
+    assert!(stats.read_errors.is_empty());
+    assert!(stats.write_errors.is_empty());
+
+    t.verify(&ops)
+}
+
+#[test]
+fn skip_read_failed_blocks() -> Result<()> {
+    const NR_BLOCKS: u64 = 1024;
+
+    let mut t = CopierTest::new(BLOCK_SIZE, NR_BLOCKS as u32, NR_BLOCKS as u32);
+    t.stamp_src_dev()?;
+    t.stamp_dst_dev()?;
+    t.invalidate_src_dev(32768..36864)?;
+
+    let ops = mk_ops(0..NR_BLOCKS, 0..NR_BLOCKS);
+    let stats = t.copy(&ops, BUFFER_SIZE).unwrap();
+    assert_eq!(stats.nr_blocks, ops.len() as u64);
+    assert_eq!(
+        stats.nr_copied.load(Ordering::Relaxed),
+        ops.len() as u64 - 1
+    );
+    assert_eq!(stats.read_errors.len(), 1);
+    assert!(stats.write_errors.is_empty());
+
+    assert_eq!(stats.read_errors[0], CopyOp { src: 1, dst: 1 });
+
+    t.verify(&ops)
+}
+
+#[test]
+fn skip_write_failed_blocks() -> Result<()> {
+    const NR_BLOCKS: u64 = 1024;
+
+    let mut t = CopierTest::new(BLOCK_SIZE, NR_BLOCKS as u32, NR_BLOCKS as u32);
+    t.stamp_src_dev()?;
+    t.stamp_dst_dev()?;
+    t.invalidate_dst_dev(32768..36864)?;
+
+    let ops = mk_ops(0..NR_BLOCKS, 0..NR_BLOCKS);
+    let stats = t.copy(&ops, BUFFER_SIZE).unwrap();
+    assert_eq!(stats.nr_blocks, ops.len() as u64);
+    assert_eq!(
+        stats.nr_copied.load(Ordering::Relaxed),
+        ops.len() as u64 - 1
+    );
+    assert!(stats.read_errors.is_empty());
+    assert_eq!(stats.write_errors.len(), 1);
+
+    assert_eq!(stats.write_errors[0], CopyOp { src: 1, dst: 1 });
+
+    t.verify(&ops)
+}
+
+#[test]
+fn skip_copy_if_all_read_failed() -> Result<()> {
+    const NR_BLOCKS: u64 = 1024;
+
+    let mut t = CopierTest::new(BLOCK_SIZE, NR_BLOCKS as u32, NR_BLOCKS as u32);
+    t.stamp_src_dev()?;
+    t.stamp_dst_dev()?;
+    t.invalidate_src_dev(0..NR_BLOCKS as u32 * BLOCK_SIZE)?;
+
+    let mut ops = mk_ops(0..NR_BLOCKS, 0..NR_BLOCKS);
+    let mut stats = t.copy(&ops, BUFFER_SIZE).unwrap();
+    assert_eq!(stats.nr_blocks, ops.len() as u64);
+    assert_eq!(stats.nr_copied.load(Ordering::Relaxed), 0);
+    assert_eq!(stats.read_errors.len(), ops.len());
+    assert!(stats.write_errors.is_empty());
+
+    ops.sort_unstable_by(|lhs, rhs| lhs.src.cmp(&rhs.src));
+    stats
+        .read_errors
+        .sort_unstable_by(|lhs, rhs| lhs.src.cmp(&rhs.src));
+    assert_eq!(ops, stats.read_errors);
+
+    t.verify(&ops)
+}
+
+#[test]
+fn skip_copy_if_all_write_failed() -> Result<()> {
+    const NR_BLOCKS: u64 = 1024;
+
+    let mut t = CopierTest::new(BLOCK_SIZE, NR_BLOCKS as u32, NR_BLOCKS as u32);
+    t.stamp_src_dev()?;
+    t.stamp_dst_dev()?;
+    t.invalidate_dst_dev(0..NR_BLOCKS as u32 * BLOCK_SIZE)?;
+
+    let mut ops = mk_ops(0..NR_BLOCKS, 0..NR_BLOCKS);
+    let mut stats = t.copy(&ops, BUFFER_SIZE).unwrap();
+    assert_eq!(stats.nr_blocks, ops.len() as u64);
+    assert_eq!(stats.nr_copied.load(Ordering::Relaxed), 0);
+    assert!(stats.read_errors.is_empty());
+    assert_eq!(stats.write_errors.len(), ops.len());
+
+    ops.sort_unstable_by(|lhs, rhs| lhs.src.cmp(&rhs.src));
+    stats
+        .write_errors
+        .sort_unstable_by(|lhs, rhs| lhs.src.cmp(&rhs.src));
+    assert_eq!(ops, stats.write_errors);
+
+    t.verify(&ops)
+}
+
+#[test]
+fn copy_length_is_less_than_buffer_size_should_success() -> Result<()> {
+    const NR_BLOCKS: u64 = 1024;
+
+    let t = CopierTest::new(BLOCK_SIZE, NR_BLOCKS as u32, NR_BLOCKS as u32);
+    t.stamp_src_dev()?;
+    t.stamp_dst_dev()?;
+
+    let ops = mk_random_ops(0..1024, 0..NR_BLOCKS, 16); // a small numbers of ops
+    let stats = t.copy(&ops, BUFFER_SIZE).unwrap();
+    assert_eq!(stats.nr_blocks, ops.len() as u64);
+    assert_eq!(stats.nr_copied.load(Ordering::Relaxed), ops.len() as u64);
+    assert!(stats.read_errors.is_empty());
+    assert!(stats.write_errors.is_empty());
+
+    t.verify(&ops)
+}
+
+#[test]
+fn copy_length_is_not_a_multiple_of_buffer_size_should_success() -> Result<()> {
+    const NR_BLOCKS: u64 = 1024;
+
+    let t = CopierTest::new(BLOCK_SIZE, NR_BLOCKS as u32, NR_BLOCKS as u32);
+    t.stamp_src_dev()?;
+    t.stamp_dst_dev()?;
+
+    let nr_ops = (BUFFER_SIZE / BLOCK_SIZE as usize) + 1;
+    let ops = mk_random_ops(0..1024, 0..NR_BLOCKS, nr_ops);
+    let stats = t.copy(&ops, BUFFER_SIZE).unwrap();
+    assert_eq!(stats.nr_blocks, ops.len() as u64);
+    assert_eq!(stats.nr_copied.load(Ordering::Relaxed), ops.len() as u64);
+    assert!(stats.read_errors.is_empty());
+    assert!(stats.write_errors.is_empty());
+
+    t.verify(&ops)
+}
+
+//------------------------------------------

--- a/src/io_engine/test_utils.rs
+++ b/src/io_engine/test_utils.rs
@@ -1,0 +1,60 @@
+use anyhow::Result;
+use std::os::unix::fs::FileExt;
+
+use crate::io_engine::base::PAGE_SIZE;
+use crate::io_engine::buffer::Buffer;
+use crate::random::Generator;
+
+//------------------------------------------
+
+pub trait BlockVisitor {
+    fn visit(&mut self, blocknr: u64) -> Result<()>;
+}
+
+pub fn visit_blocks(nr_blocks: u64, v: &mut dyn BlockVisitor) -> Result<()> {
+    for b in 0..nr_blocks {
+        v.visit(b)?;
+    }
+    Ok(())
+}
+
+//------------------------------------------
+
+pub struct Stamper<T> {
+    dev: T,
+    block_size: usize, // bytes
+    seed: u64,
+    buf: Buffer,
+    offset: u64, // bytes
+}
+
+impl<T: FileExt> Stamper<T> {
+    pub fn new(dev: T, seed: u64, block_size: usize) -> Self {
+        let buf = Buffer::new(block_size, PAGE_SIZE);
+        Self {
+            dev,
+            block_size,
+            seed,
+            buf,
+            offset: 0,
+        }
+    }
+
+    pub fn offset(mut self, offset: u64) -> Self {
+        self.offset = offset;
+        self
+    }
+}
+
+impl<T: FileExt> BlockVisitor for Stamper<T> {
+    fn visit(&mut self, blocknr: u64) -> Result<()> {
+        let mut gen = Generator::new();
+        gen.fill_buffer(self.seed ^ blocknr, self.buf.get_data())?;
+
+        let offset = blocknr * self.block_size as u64 + self.offset;
+        self.dev.write_all_at(self.buf.get_data(), offset)?;
+        Ok(())
+    }
+}
+
+//------------------------------------------

--- a/src/io_engine/utils.rs
+++ b/src/io_engine/utils.rs
@@ -3,6 +3,9 @@ use iovec::{unix, IoVec};
 
 use crate::io_engine::VectoredIo;
 
+#[cfg(test)]
+mod tests;
+
 //-------------------------------------
 
 pub trait ReadBlocks {

--- a/src/io_engine/utils.rs
+++ b/src/io_engine/utils.rs
@@ -1,90 +1,102 @@
 use anyhow::{anyhow, Result};
 use iovec::{unix, IoVec};
-use std::fs::File;
-use std::os::unix::io::AsRawFd;
 
-///-------------------------------------
+use crate::io_engine::VectoredIo;
 
-// All the individual buffers are assumed to be the same size.  If io fails, the first block
-// will be marked as errored, and the io will be retried from the subsequent block.
-pub fn read_blocks<'a>(
-    src: &File,
-    buffers: &'a mut [&'a mut [u8]],
-    mut pos: u64,
-) -> Result<Vec<Result<()>>> {
-    let block_size = buffers[0].len();
-    let mut remaining = 0;
-    let mut bufs: Vec<&'a mut IoVec> = Vec::with_capacity(buffers.len());
-    for b in buffers.iter_mut() {
-        assert_eq!(b.len(), block_size);
-        remaining += b.len();
-        bufs.push((*b).into());
-    }
-    let mut os_bufs = unix::as_os_slice_mut(&mut bufs[..]);
-    let mut results = Vec::with_capacity(os_bufs.len());
+//-------------------------------------
 
-    while remaining > 0 {
-        let ptr = os_bufs.as_ptr();
-        let n = unsafe { libc::preadv64(src.as_raw_fd(), ptr, os_bufs.len() as i32, pos as i64) };
-
-        if n > 0 {
-            remaining -= n as usize;
-            pos += n as u64;
-            assert_eq!(n as usize % block_size, 0);
-            os_bufs = &mut os_bufs[(n as usize / block_size)..];
-            for _ in 0..(n as usize / block_size) {
-                results.push(Ok(()));
-            }
-        } else {
-            // Skip to the next iovec
-            remaining -= block_size;
-            pos += block_size as u64;
-            os_bufs = &mut os_bufs[1..];
-            results.push(Err(anyhow!("read failed")));
-        }
-    }
-
-    Ok(results)
+pub trait ReadBlocks {
+    // All the individual buffers are assumed to be the same size.
+    fn read_blocks(&self, buffers: &mut [&mut [u8]], pos: u64) -> Result<Vec<Result<()>>>;
 }
 
-pub fn write_blocks<'a>(
-    src: &File,
-    buffers: &'a [&'a [u8]],
-    mut pos: u64,
-) -> Result<Vec<Result<()>>> {
-    let block_size = buffers[0].len();
-    let mut remaining = 0;
-    let mut bufs: Vec<&'a IoVec> = Vec::with_capacity(buffers.len());
-    for b in buffers.iter() {
-        assert_eq!(b.len(), block_size);
-        remaining += b.len();
-        bufs.push((*b).into());
+pub trait WriteBlocks {
+    // All the individual buffers are assumed to be the same size.
+    fn write_blocks(&self, buffers: &[&[u8]], pos: u64) -> Result<Vec<Result<()>>>;
+}
+
+//-------------------------------------
+
+pub struct VectoredBlockIo<T> {
+    dev: T,
+}
+
+impl<T: VectoredIo> From<T> for VectoredBlockIo<T> {
+    fn from(dev: T) -> VectoredBlockIo<T> {
+        VectoredBlockIo { dev }
     }
-    let mut os_bufs = unix::as_os_slice(&bufs[..]);
-    let mut results = Vec::with_capacity(os_bufs.len());
+}
 
-    while remaining > 0 {
-        let ptr = os_bufs.as_ptr();
-        let n = unsafe { libc::pwritev64(src.as_raw_fd(), ptr, os_bufs.len() as i32, pos as i64) };
-
-        if n > 0 {
-            remaining -= n as usize;
-            pos += n as u64;
-            assert_eq!(n as usize % block_size, 0);
-            os_bufs = &os_bufs[(n as usize / block_size)..];
-            for _ in 0..(n as usize / block_size) {
-                results.push(Ok(()));
-            }
-        } else {
-            // Skip to the next iovec
-            remaining -= block_size;
-            pos += block_size as u64;
-            os_bufs = &os_bufs[1..];
-            results.push(Err(anyhow!("read failed")));
+impl<T: VectoredIo> ReadBlocks for VectoredBlockIo<T> {
+    // If io fails, the first block will be marked as errored,
+    // and the io will be retried from the subsequent block.
+    fn read_blocks(&self, buffers: &mut [&mut [u8]], mut pos: u64) -> Result<Vec<Result<()>>> {
+        let block_size = buffers[0].len();
+        let mut remaining = 0;
+        let mut bufs: Vec<&mut IoVec> = Vec::with_capacity(buffers.len());
+        for b in buffers.iter_mut() {
+            assert_eq!(b.len(), block_size);
+            remaining += b.len();
+            bufs.push((*b).into());
         }
-    }
+        let mut os_bufs = unix::as_os_slice_mut(&mut bufs[..]);
+        let mut results = Vec::with_capacity(os_bufs.len());
 
-    Ok(results)
+        while remaining > 0 {
+            if let Ok(n) = self.dev.read_vectored_at(os_bufs, pos) {
+                remaining -= n as usize;
+                pos += n as u64;
+                assert_eq!(n as usize % block_size, 0);
+                os_bufs = &mut os_bufs[(n as usize / block_size)..];
+                for _ in 0..(n as usize / block_size) {
+                    results.push(Ok(()));
+                }
+            } else {
+                // Skip to the next iovec
+                remaining -= block_size;
+                pos += block_size as u64;
+                os_bufs = &mut os_bufs[1..];
+                results.push(Err(anyhow!("read failed")));
+            }
+        }
+
+        Ok(results)
+    }
+}
+
+impl<T: VectoredIo> WriteBlocks for VectoredBlockIo<T> {
+    fn write_blocks(&self, buffers: &[&[u8]], mut pos: u64) -> Result<Vec<Result<()>>> {
+        let block_size = buffers[0].len();
+        let mut remaining = 0;
+        let mut bufs: Vec<&IoVec> = Vec::with_capacity(buffers.len());
+        for b in buffers.iter() {
+            assert_eq!(b.len(), block_size);
+            remaining += b.len();
+            bufs.push((*b).into());
+        }
+        let mut os_bufs = unix::as_os_slice(&bufs[..]);
+        let mut results = Vec::with_capacity(os_bufs.len());
+
+        while remaining > 0 {
+            if let Ok(n) = self.dev.write_vectored_at(os_bufs, pos) {
+                remaining -= n as usize;
+                pos += n as u64;
+                assert_eq!(n as usize % block_size, 0);
+                os_bufs = &os_bufs[(n as usize / block_size)..];
+                for _ in 0..(n as usize / block_size) {
+                    results.push(Ok(()));
+                }
+            } else {
+                // Skip to the next iovec
+                remaining -= block_size;
+                pos += block_size as u64;
+                os_bufs = &os_bufs[1..];
+                results.push(Err(anyhow!("read failed")));
+            }
+        }
+
+        Ok(results)
+    }
 }
 
 //-------------------------------------

--- a/src/io_engine/utils/tests.rs
+++ b/src/io_engine/utils/tests.rs
@@ -1,0 +1,242 @@
+use super::*;
+
+use roaring::RoaringBitmap;
+use std::ops::{Range, Sub};
+use std::vec::Vec;
+
+use crate::io_engine::buffer::Buffer;
+use crate::io_engine::ramdisk::Ramdisk;
+use crate::math::div_up;
+
+//-------------------------------------
+
+fn length<T: Copy + Sub<Output = T>>(r: &Range<T>) -> T {
+    r.end - r.start
+}
+
+//-------------------------------------
+
+struct TestContext {
+    disk: Ramdisk,
+    block_size: u32,
+    offset: u32,
+    faulty_blocks: RoaringBitmap,
+}
+
+impl TestContext {
+    // Ramdisk is u32-based
+    fn new(disk_size: u32, block_size: u32) -> Self {
+        Self {
+            disk: Ramdisk::new(disk_size),
+            block_size,
+            offset: 0,
+            faulty_blocks: RoaringBitmap::new(),
+        }
+    }
+
+    #[allow(dead_code)]
+    fn offset(mut self, offset: u32) -> Self {
+        self.offset = offset;
+        self
+    }
+
+    fn get_block_size(&self) -> u32 {
+        self.block_size
+    }
+
+    fn set_faulty(&mut self, bytes: std::ops::Range<u32>) {
+        self.disk.invalidate(bytes.clone());
+
+        let block_begin = (bytes.start - self.offset) / self.block_size;
+        let block_end = div_up(bytes.end - self.offset, self.block_size);
+        for b in block_begin..block_end {
+            self.faulty_blocks.push(b);
+        }
+    }
+}
+
+//-------------------------------------
+
+trait Validator {
+    fn validate(&self, blocks: Range<u64>, results: &[anyhow::Result<()>]);
+}
+
+struct ReadWriteTest<T, V> {
+    dev: T,
+    block_size: usize,
+    offset: u64,
+    validator: V,
+}
+
+impl<T: ReadBlocks + WriteBlocks, V: Validator> ReadWriteTest<T, V> {
+    fn new(dev: T, block_size: usize, validator: V) -> ReadWriteTest<T, V> {
+        ReadWriteTest {
+            dev,
+            block_size,
+            offset: 0,
+            validator,
+        }
+    }
+
+    #[allow(dead_code)]
+    fn offset(mut self, offset: u64) -> Self {
+        self.offset = offset;
+        self
+    }
+
+    fn test_read(&self, blocks: Range<u64>) {
+        let buf = Buffer::new(self.block_size * length(&blocks) as usize, 4096);
+        let mut bufs: Vec<&mut [u8]> = buf
+            .get_data()
+            .chunks_mut(self.block_size as usize)
+            .collect();
+        let pos = self.offset + blocks.start * self.block_size as u64;
+        let ret = self.dev.read_blocks(&mut bufs, pos);
+        assert!(ret.is_ok());
+        self.validator.validate(blocks, &ret.unwrap());
+    }
+
+    fn test_write(&self, blocks: Range<u64>) {
+        let buf = Buffer::new(self.block_size * length(&blocks) as usize, 4096);
+        let bufs: Vec<&[u8]> = buf.get_data().chunks(self.block_size as usize).collect();
+        let pos = self.offset + blocks.start * self.block_size as u64;
+        let ret = self.dev.write_blocks(&bufs, pos);
+        assert!(ret.is_ok());
+        self.validator.validate(blocks, &ret.unwrap());
+    }
+}
+
+//-------------------------------------
+
+const BLOCK_SIZE: u32 = 8192; // bytes
+const RAMDISK_SIZE: u32 = 65536; // bytes
+
+mod vectored_io {
+    use super::*;
+
+    struct VectoredIoValidator {
+        faulty_blocks: RoaringBitmap,
+    }
+
+    impl VectoredIoValidator {
+        fn new(faulty_blocks: RoaringBitmap) -> Self {
+            Self { faulty_blocks }
+        }
+    }
+
+    impl Validator for VectoredIoValidator {
+        fn validate(&self, blocks: Range<u64>, results: &[anyhow::Result<()>]) {
+            let nr_blocks = length(&blocks) as usize;
+            assert_eq!(results.len(), nr_blocks);
+
+            // trait ExactSizeIterator is not implemented for Range<u64> (rust-lang pr#22299)
+            // so we cannot do reverse traversal like rev() or rposition().
+            let mut err_len = 0;
+            for (i, b) in blocks.enumerate() {
+                if self.faulty_blocks.contains(b as u32) {
+                    err_len = i + 1;
+                }
+            }
+
+            // all the blocks before the last faulty one should fail
+            for r in results.iter().take(err_len) {
+                assert!(r.is_err());
+            }
+            for r in results.iter().skip(err_len) {
+                assert!(r.is_ok());
+            }
+        }
+    }
+
+    impl From<RoaringBitmap> for VectoredIoValidator {
+        fn from(faulty_blocks: RoaringBitmap) -> VectoredIoValidator {
+            VectoredIoValidator::new(faulty_blocks)
+        }
+    }
+
+    fn to_vectored_test(
+        ctx: TestContext,
+    ) -> ReadWriteTest<VectoredBlockIo<Ramdisk>, VectoredIoValidator> {
+        let block_size = ctx.get_block_size() as usize;
+        let validator = VectoredIoValidator::from(ctx.faulty_blocks);
+        ReadWriteTest::new(VectoredBlockIo::from(ctx.disk), block_size, validator)
+    }
+
+    //-------------------------------------
+
+    #[test]
+    fn read_from_the_faulty_block_should_skip() {
+        let mut ctx = TestContext::new(RAMDISK_SIZE, BLOCK_SIZE);
+        ctx.set_faulty(0..512);
+
+        let t = to_vectored_test(ctx);
+        t.test_read(0..4);
+    }
+
+    #[test]
+    fn read_overlap_the_faulty_block_should_skip() {
+        let mut ctx = TestContext::new(RAMDISK_SIZE, BLOCK_SIZE);
+        ctx.set_faulty(BLOCK_SIZE..BLOCK_SIZE + 512);
+
+        let t = to_vectored_test(ctx);
+        t.test_read(0..4);
+    }
+
+    #[test]
+    fn read_until_the_faulty_block_should_fail() {
+        let mut ctx = TestContext::new(RAMDISK_SIZE, BLOCK_SIZE);
+        ctx.set_faulty((RAMDISK_SIZE - 512)..RAMDISK_SIZE);
+
+        let t = to_vectored_test(ctx);
+        let nr_blocks = RAMDISK_SIZE / BLOCK_SIZE;
+        t.test_read(0..nr_blocks as u64);
+    }
+
+    #[test]
+    fn read_before_the_faulty_block_should_success() {
+        let mut ctx = TestContext::new(RAMDISK_SIZE, BLOCK_SIZE);
+        ctx.set_faulty((RAMDISK_SIZE - 4096)..RAMDISK_SIZE);
+
+        let t = to_vectored_test(ctx);
+        t.test_read(0..4);
+    }
+
+    #[test]
+    fn write_to_the_faulty_block_should_skip() {
+        let mut ctx = TestContext::new(RAMDISK_SIZE, BLOCK_SIZE);
+        ctx.set_faulty(0..512);
+
+        let t = to_vectored_test(ctx);
+        t.test_write(0..4);
+    }
+
+    #[test]
+    fn write_overlap_the_faulty_block_should_skip() {
+        let mut ctx = TestContext::new(RAMDISK_SIZE, BLOCK_SIZE);
+        ctx.set_faulty(BLOCK_SIZE..BLOCK_SIZE + 512);
+
+        let t = to_vectored_test(ctx);
+        t.test_write(0..4);
+    }
+
+    #[test]
+    fn write_until_the_faulty_block_should_fail() {
+        let mut ctx = TestContext::new(RAMDISK_SIZE, BLOCK_SIZE);
+        ctx.set_faulty((RAMDISK_SIZE - 512)..RAMDISK_SIZE);
+
+        let t = to_vectored_test(ctx);
+        let nr_blocks = RAMDISK_SIZE / BLOCK_SIZE;
+        t.test_write(0..nr_blocks as u64);
+    }
+
+    #[test]
+    fn write_before_the_faulty_block_should_success() {
+        let mut ctx = TestContext::new(RAMDISK_SIZE, BLOCK_SIZE);
+        ctx.set_faulty((RAMDISK_SIZE - 4096)..RAMDISK_SIZE);
+
+        let t = to_vectored_test(ctx);
+        t.test_write(0..4);
+    }
+}
+
+//-------------------------------------

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,3 +29,6 @@ pub mod units;
 pub mod version;
 pub mod write_batcher;
 pub mod xml;
+
+#[cfg(any(test, feature = "devtools"))]
+pub mod random;

--- a/src/random.rs
+++ b/src/random.rs
@@ -60,4 +60,10 @@ impl Generator {
     }
 }
 
+impl Default for Generator {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 //------------------------------------

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -12,7 +12,6 @@ pub mod input_arg;
 pub mod output_option;
 pub mod process;
 pub mod program;
-pub mod random;
 pub mod target;
 pub mod test_dir;
 pub mod thin;

--- a/tests/thin_shrink.rs
+++ b/tests/thin_shrink.rs
@@ -6,13 +6,13 @@ use std::io::{Read, Seek, SeekFrom, Write};
 use std::path::Path;
 
 use thinp::file_utils;
+use thinp::random::Generator;
 use thinp::thin::ir::{self, MetadataVisitor, Visit};
 use thinp::thin::xml;
 
 mod common;
 
 use common::process::*;
-use common::random::Generator;
 use common::target::*;
 use common::test_dir::*;
 use common::thin::*;


### PR DESCRIPTION
- Decouple the Copier from physical files, by introducing the abstraction layers for block io and vectored read/write.
- Handle blocks ignored by vectored read/write with direct io
- Try harder to maximize data recovery rate by copying failure blocks page-by-page
- Add unit tests for the Copiers. The tests include error handling and data integrity.
- Minor enhancements: Improve efficiency of v1 metadata update; remove unnecessary locks