### PR TITLE
Minor fixes

### DIFF
--- a/src/cache/check.rs
+++ b/src/cache/check.rs
@@ -377,6 +377,10 @@ pub fn check(opts: CacheCheckOptions) -> anyhow::Result<()> {
         return Err(anyhow!("metadata contains errors"));
     }
 
+    if opts.skip_mappings || opts.skip_hints || opts.skip_discards {
+        return Ok(());
+    }
+
     let root = unpack::<SMRoot>(&sb.metadata_sm_root[0..])?;
     let metadata_leaks = check_metadata_space_map(
         engine.clone(),

--- a/src/cache/writeback.rs
+++ b/src/cache/writeback.rs
@@ -64,7 +64,7 @@ impl ProgressReporter {
     /// Adds stats into the internal base.  Then updates the progress.
     fn inc_stats(&self, stats: &CopyStats) {
         let mut inner = self.inner.lock().unwrap();
-        inner.nr_copied += stats.nr_copied.load(Ordering::Relaxed);
+        inner.nr_copied += stats.nr_copied;
         inner.nr_read_errors += stats.read_errors.len() as u64;
         inner.nr_write_errors += stats.write_errors.len() as u64;
 
@@ -98,8 +98,7 @@ impl CopyProgress for ProgressReporter {
             inner.nr_write_errors + stats.write_errors.len() as u64
         ));
 
-        let percent =
-            ((inner.nr_copied + stats.nr_copied.load(Ordering::Relaxed)) * 100) / inner.nr_blocks;
+        let percent = (inner.nr_copied + stats.nr_copied * 100) / inner.nr_blocks;
         self.report.progress(percent as u8);
     }
 }

--- a/src/commands/cache_check.rs
+++ b/src/commands/cache_check.rs
@@ -61,7 +61,7 @@ impl CacheCheckCommand {
             )
             .arg(
                 Arg::new("SKIP_MAPPINGS")
-                    .help("Don't check the mapping tree")
+                    .help("Don't check the mapping array")
                     .long("skip-mappings"),
             )
             // arguments

--- a/src/commands/thin_delta.rs
+++ b/src/commands/thin_delta.rs
@@ -101,7 +101,7 @@ impl<'a> Command<'a> for ThinDeltaCommand {
             Snap::RootBlock(matches.value_of_t_or_exit::<u64>("ROOT2"))
         };
 
-        let engine_opts = parse_engine_opts(ToolType::Era, &matches);
+        let engine_opts = parse_engine_opts(ToolType::Thin, &matches);
         if engine_opts.is_err() {
             return to_exit_code(&report, engine_opts);
         }

--- a/src/commands/thin_dump.rs
+++ b/src/commands/thin_dump.rs
@@ -47,6 +47,13 @@ impl ThinDumpCommand {
                     .value_name("SECTORS"),
             )
             .arg(
+                Arg::new("DEV_ID")
+                    .help("Dump the specified device")
+                    .long("dev-id")
+                    .multiple_occurrences(true)
+                    .value_name("THIN_ID"),
+            )
+            .arg(
                 Arg::new("METADATA_SNAPSHOT")
                     .help("Access the metadata snapshot on a live pool")
                     .short('m')
@@ -117,6 +124,16 @@ impl<'a> Command<'a> for ThinDumpCommand {
             return to_exit_code(&report, engine_opts);
         }
 
+        let selected_devs = if matches.is_present("DEV_ID") {
+            let devs: Vec<u64> = matches
+                .values_of_t_or_exit::<u64>("DEV_ID")
+                .into_iter()
+                .collect();
+            Some(devs)
+        } else {
+            None
+        };
+
         let opts = ThinDumpOptions {
             input: input_file,
             output: output_file,
@@ -129,6 +146,7 @@ impl<'a> Command<'a> for ThinDumpCommand {
                 data_block_size: optional_value_or_exit::<u32>(&matches, "DATA_BLOCK_SIZE"),
                 nr_data_blocks: optional_value_or_exit::<u64>(&matches, "NR_DATA_BLOCKS"),
             },
+            selected_devs,
         };
 
         to_exit_code(&report, dump(opts))

--- a/src/commands/thin_dump.rs
+++ b/src/commands/thin_dump.rs
@@ -130,7 +130,7 @@ impl<'a> Command<'a> for ThinDumpCommand {
             Arc::new(mk_simple_report())
         };
 
-        let engine_opts = parse_engine_opts(ToolType::Era, &matches);
+        let engine_opts = parse_engine_opts(ToolType::Thin, &matches);
         if engine_opts.is_err() {
             return to_exit_code(&report, engine_opts);
         }

--- a/src/commands/thin_dump.rs
+++ b/src/commands/thin_dump.rs
@@ -10,7 +10,7 @@ use crate::commands::engine::*;
 use crate::commands::utils::*;
 use crate::commands::Command;
 use crate::report::*;
-use crate::thin::dump::{dump, ThinDumpOptions};
+use crate::thin::dump::{dump, OutputFormat, ThinDumpOptions};
 use crate::thin::metadata_repair::SuperblockOverrides;
 
 pub struct ThinDumpCommand;
@@ -52,6 +52,17 @@ impl ThinDumpCommand {
                     .long("dev-id")
                     .multiple_occurrences(true)
                     .value_name("THIN_ID"),
+            )
+            .arg(
+                Arg::new("FORMAT")
+                    .help("Choose the output format")
+                    .short('f')
+                    .long("format")
+                    .value_name("TYPE")
+                    .possible_values(["xml", "human_readable"])
+                    .hide_possible_values(true)
+                    .default_value("xml")
+                    .hide_default_value(true),
             )
             .arg(
                 Arg::new("METADATA_SNAPSHOT")
@@ -147,6 +158,7 @@ impl<'a> Command<'a> for ThinDumpCommand {
                 nr_data_blocks: optional_value_or_exit::<u64>(&matches, "NR_DATA_BLOCKS"),
             },
             selected_devs,
+            format: matches.value_of_t_or_exit::<OutputFormat>("FORMAT"),
         };
 
         to_exit_code(&report, dump(opts))

--- a/src/commands/thin_ls.rs
+++ b/src/commands/thin_ls.rs
@@ -69,7 +69,7 @@ impl<'a> Command<'a> for ThinLsCommand {
             vec![DeviceId, Mapped, CreationTime, SnapshottedTime]
         };
 
-        let engine_opts = parse_engine_opts(ToolType::Era, &matches);
+        let engine_opts = parse_engine_opts(ToolType::Thin, &matches);
         if engine_opts.is_err() {
             return to_exit_code(&report, engine_opts);
         }

--- a/src/commands/thin_repair.rs
+++ b/src/commands/thin_repair.rs
@@ -77,7 +77,7 @@ impl<'a> Command<'a> for ThinRepairCommand {
         check_input_file(input_file, &report);
         check_output_file(output_file, &report);
 
-        let engine_opts = parse_engine_opts(ToolType::Era, &matches);
+        let engine_opts = parse_engine_opts(ToolType::Thin, &matches);
         if engine_opts.is_err() {
             return to_exit_code(&report, engine_opts);
         }

--- a/src/commands/thin_restore.rs
+++ b/src/commands/thin_restore.rs
@@ -77,7 +77,7 @@ impl<'a> Command<'a> for ThinRestoreCommand {
         check_input_file(input_file, &report);
         check_output_file(output_file, &report);
 
-        let engine_opts = parse_engine_opts(ToolType::Era, &matches);
+        let engine_opts = parse_engine_opts(ToolType::Thin, &matches);
         if engine_opts.is_err() {
             return to_exit_code(&report, engine_opts);
         }

--- a/src/commands/thin_rmap.rs
+++ b/src/commands/thin_rmap.rs
@@ -92,7 +92,7 @@ impl<'a> Command<'a> for ThinRmapCommand {
             })
             .collect();
 
-        let engine_opts = parse_engine_opts(ToolType::Era, &matches);
+        let engine_opts = parse_engine_opts(ToolType::Thin, &matches);
         if engine_opts.is_err() {
             return to_exit_code(&report, engine_opts);
         }

--- a/src/commands/thin_trim.rs
+++ b/src/commands/thin_trim.rs
@@ -58,7 +58,7 @@ impl<'a> Command<'a> for ThinTrimCommand {
         check_input_file(metadata_dev, &report);
         check_input_file(data_dev, &report);
 
-        let engine_opts = parse_engine_opts(ToolType::Era, &matches);
+        let engine_opts = parse_engine_opts(ToolType::Thin, &matches);
         if engine_opts.is_err() {
             return to_exit_code(&report, engine_opts);
         }

--- a/src/commands/utils.rs
+++ b/src/commands/utils.rs
@@ -92,7 +92,7 @@ where
     }
 }
 
-pub fn to_exit_code<T>(report: &Arc<Report>, result: anyhow::Result<T>) -> exitcode::ExitCode {
+pub fn to_exit_code<T>(report: &Report, result: anyhow::Result<T>) -> exitcode::ExitCode {
     if let Err(e) = result {
         report.fatal(&format!("{}", e));
 

--- a/src/io_engine/copier.rs
+++ b/src/io_engine/copier.rs
@@ -1,5 +1,4 @@
 use anyhow::Result;
-use std::sync::atomic::AtomicU64;
 use std::sync::Arc;
 
 //-------------------------------------
@@ -15,7 +14,7 @@ pub struct CopyOp {
 #[derive(Debug)]
 pub struct CopyStats {
     pub nr_blocks: Block,
-    pub nr_copied: AtomicU64,
+    pub nr_copied: Block,
     pub read_errors: Vec<CopyOp>,
     pub write_errors: Vec<CopyOp>,
 }
@@ -24,7 +23,7 @@ impl CopyStats {
     pub fn new(nr_blocks: u64) -> Self {
         Self {
             nr_blocks,
-            nr_copied: AtomicU64::new(0),
+            nr_copied: 0,
             read_errors: Vec::new(),
             write_errors: Vec::new(),
         }

--- a/src/io_engine/rescue_copier.rs
+++ b/src/io_engine/rescue_copier.rs
@@ -4,7 +4,6 @@ use std::fs::{File, OpenOptions};
 use std::os::unix::fs::FileExt;
 use std::os::unix::fs::OpenOptionsExt;
 use std::path::Path;
-use std::sync::atomic::Ordering;
 use std::sync::Arc;
 
 use crate::io_engine::buffer::*;
@@ -141,7 +140,7 @@ impl<T: FileExt + 'static> Copier for RescueCopier<T> {
             }
         }
 
-        stats.nr_copied.fetch_add(nr_copied, Ordering::SeqCst);
+        stats.nr_copied += nr_copied as u64;
         progress.update(&stats);
 
         Ok(stats)

--- a/src/io_engine/rescue_copier/tests.rs
+++ b/src/io_engine/rescue_copier/tests.rs
@@ -226,7 +226,7 @@ fn copy_completed_blocks() -> Result<()> {
     let ops = mk_random_ops(0..NR_BLOCKS, 0..NR_BLOCKS, NR_BLOCKS as usize);
     let stats = t.copy(&ops).unwrap();
     assert_eq!(stats.nr_blocks, ops.len() as u64);
-    assert_eq!(stats.nr_copied.load(Ordering::Relaxed), ops.len() as u64);
+    assert_eq!(stats.nr_copied, ops.len() as u64);
     assert!(stats.read_errors.is_empty());
     assert!(stats.write_errors.is_empty());
 
@@ -244,10 +244,7 @@ fn partial_copy_with_unreadable_pages() -> Result<()> {
     let ops = mk_random_ops(0..NR_BLOCKS, 0..NR_BLOCKS, NR_BLOCKS as usize);
     let stats = t.copy(&ops).unwrap();
     assert_eq!(stats.nr_blocks, ops.len() as u64);
-    assert_eq!(
-        stats.nr_copied.load(Ordering::Relaxed),
-        ops.len() as u64 - 1
-    );
+    assert_eq!(stats.nr_copied, ops.len() as u64 - 1);
     assert_eq!(stats.read_errors.len(), 1);
     assert!(stats.write_errors.is_empty());
 
@@ -267,10 +264,7 @@ fn partial_copy_with_unwritable_pages() -> Result<()> {
     let ops = mk_random_ops(0..NR_BLOCKS, 0..NR_BLOCKS, NR_BLOCKS as usize);
     let stats = t.copy(&ops).unwrap();
     assert_eq!(stats.nr_blocks, ops.len() as u64);
-    assert_eq!(
-        stats.nr_copied.load(Ordering::Relaxed),
-        ops.len() as u64 - 1
-    );
+    assert_eq!(stats.nr_copied, ops.len() as u64 - 1);
     assert!(stats.read_errors.is_empty());
     assert_eq!(stats.write_errors.len(), 1);
 
@@ -291,10 +285,7 @@ fn partial_copy_with_unreadable_and_unwritable_pages() -> Result<()> {
     let ops = mk_random_ops(0..NR_BLOCKS, 0..NR_BLOCKS, NR_BLOCKS as usize);
     let stats = t.copy(&ops).unwrap();
     assert_eq!(stats.nr_blocks, ops.len() as u64);
-    assert_eq!(
-        stats.nr_copied.load(Ordering::Relaxed),
-        ops.len() as u64 - 2
-    );
+    assert_eq!(stats.nr_copied, ops.len() as u64 - 2);
     assert_eq!(stats.read_errors.len(), 1);
     assert_eq!(stats.write_errors.len(), 1);
 

--- a/src/io_engine/sync_copier.rs
+++ b/src/io_engine/sync_copier.rs
@@ -4,7 +4,6 @@ use std::fs::File;
 use std::fs::OpenOptions;
 use std::os::unix::fs::OpenOptionsExt;
 use std::path::Path;
-use std::sync::atomic::Ordering;
 use std::sync::mpsc;
 use std::sync::{Arc, Mutex, RwLock};
 use std::thread;
@@ -289,10 +288,8 @@ impl<T: ReadBlocks + WriteBlocks + Send + 'static> Copier for SyncCopier<T> {
                     }
                 }
 
-                let stats = stats.read().unwrap();
-                stats
-                    .nr_copied
-                    .fetch_add(write_success.len(), Ordering::SeqCst);
+                let mut stats = stats.write().unwrap();
+                stats.nr_copied += write_success.len() as u64;
                 progress.update(&*stats);
             })
         };

--- a/src/io_engine/sync_copier/tests.rs
+++ b/src/io_engine/sync_copier/tests.rs
@@ -235,7 +235,7 @@ fn mirroring() -> Result<()> {
     let ops = mk_ops(0..NR_BLOCKS, 0..NR_BLOCKS);
     let stats = t.copy(&ops, BUFFER_SIZE).unwrap();
     assert_eq!(stats.nr_blocks, ops.len() as u64);
-    assert_eq!(stats.nr_copied.load(Ordering::Relaxed), ops.len() as u64);
+    assert_eq!(stats.nr_copied, ops.len() as u64);
     assert!(stats.read_errors.is_empty());
     assert!(stats.write_errors.is_empty());
 
@@ -255,7 +255,7 @@ fn copy_with_ops_sorted_by_src() -> Result<()> {
     let ops = mk_ops(0..NR_BLOCKS, (0..NR_BLOCKS).rev());
     let stats = t.copy(&ops, BUFFER_SIZE).unwrap();
     assert_eq!(stats.nr_blocks, NR_BLOCKS);
-    assert_eq!(stats.nr_copied.load(Ordering::Relaxed), NR_BLOCKS);
+    assert_eq!(stats.nr_copied, NR_BLOCKS);
     assert!(stats.read_errors.is_empty());
     assert!(stats.write_errors.is_empty());
 
@@ -275,7 +275,7 @@ fn copy_with_ops_sorted_by_dst() -> Result<()> {
     let ops = mk_ops((0..NR_BLOCKS).rev(), 0..NR_BLOCKS);
     let stats = t.copy(&ops, BUFFER_SIZE).unwrap();
     assert_eq!(stats.nr_blocks, ops.len() as u64);
-    assert_eq!(stats.nr_copied.load(Ordering::Relaxed), ops.len() as u64);
+    assert_eq!(stats.nr_copied, ops.len() as u64);
     assert!(stats.read_errors.is_empty());
     assert!(stats.write_errors.is_empty());
 
@@ -294,7 +294,7 @@ fn copy_randomly() -> Result<()> {
     let ops = mk_random_ops(0..NR_BLOCKS, 0..NR_BLOCKS, nr_ops);
     let stats = t.copy(&ops, BUFFER_SIZE).unwrap();
     assert_eq!(stats.nr_blocks, ops.len() as u64);
-    assert_eq!(stats.nr_copied.load(Ordering::Relaxed), ops.len() as u64);
+    assert_eq!(stats.nr_copied, ops.len() as u64);
     assert!(stats.read_errors.is_empty());
     assert!(stats.write_errors.is_empty());
 
@@ -313,10 +313,7 @@ fn skip_read_failed_blocks() -> Result<()> {
     let ops = mk_ops(0..NR_BLOCKS, 0..NR_BLOCKS);
     let stats = t.copy(&ops, BUFFER_SIZE).unwrap();
     assert_eq!(stats.nr_blocks, ops.len() as u64);
-    assert_eq!(
-        stats.nr_copied.load(Ordering::Relaxed),
-        ops.len() as u64 - 1
-    );
+    assert_eq!(stats.nr_copied, ops.len() as u64 - 1);
     assert_eq!(stats.read_errors.len(), 1);
     assert!(stats.write_errors.is_empty());
 
@@ -337,10 +334,7 @@ fn skip_write_failed_blocks() -> Result<()> {
     let ops = mk_ops(0..NR_BLOCKS, 0..NR_BLOCKS);
     let stats = t.copy(&ops, BUFFER_SIZE).unwrap();
     assert_eq!(stats.nr_blocks, ops.len() as u64);
-    assert_eq!(
-        stats.nr_copied.load(Ordering::Relaxed),
-        ops.len() as u64 - 1
-    );
+    assert_eq!(stats.nr_copied, ops.len() as u64 - 1);
     assert!(stats.read_errors.is_empty());
     assert_eq!(stats.write_errors.len(), 1);
 
@@ -361,7 +355,7 @@ fn skip_copy_if_all_read_failed() -> Result<()> {
     let mut ops = mk_ops(0..NR_BLOCKS, 0..NR_BLOCKS);
     let mut stats = t.copy(&ops, BUFFER_SIZE).unwrap();
     assert_eq!(stats.nr_blocks, ops.len() as u64);
-    assert_eq!(stats.nr_copied.load(Ordering::Relaxed), 0);
+    assert_eq!(stats.nr_copied, 0);
     assert_eq!(stats.read_errors.len(), ops.len());
     assert!(stats.write_errors.is_empty());
 
@@ -386,7 +380,7 @@ fn skip_copy_if_all_write_failed() -> Result<()> {
     let mut ops = mk_ops(0..NR_BLOCKS, 0..NR_BLOCKS);
     let mut stats = t.copy(&ops, BUFFER_SIZE).unwrap();
     assert_eq!(stats.nr_blocks, ops.len() as u64);
-    assert_eq!(stats.nr_copied.load(Ordering::Relaxed), 0);
+    assert_eq!(stats.nr_copied, 0);
     assert!(stats.read_errors.is_empty());
     assert_eq!(stats.write_errors.len(), ops.len());
 
@@ -410,7 +404,7 @@ fn copy_length_is_less_than_buffer_size_should_success() -> Result<()> {
     let ops = mk_random_ops(0..1024, 0..NR_BLOCKS, 16); // a small numbers of ops
     let stats = t.copy(&ops, BUFFER_SIZE).unwrap();
     assert_eq!(stats.nr_blocks, ops.len() as u64);
-    assert_eq!(stats.nr_copied.load(Ordering::Relaxed), ops.len() as u64);
+    assert_eq!(stats.nr_copied, ops.len() as u64);
     assert!(stats.read_errors.is_empty());
     assert!(stats.write_errors.is_empty());
 
@@ -429,7 +423,7 @@ fn copy_length_is_not_a_multiple_of_buffer_size_should_success() -> Result<()> {
     let ops = mk_random_ops(0..1024, 0..NR_BLOCKS, nr_ops);
     let stats = t.copy(&ops, BUFFER_SIZE).unwrap();
     assert_eq!(stats.nr_blocks, ops.len() as u64);
-    assert_eq!(stats.nr_copied.load(Ordering::Relaxed), ops.len() as u64);
+    assert_eq!(stats.nr_copied, ops.len() as u64);
     assert!(stats.read_errors.is_empty());
     assert!(stats.write_errors.is_empty());
 

--- a/src/thin/delta_visitor.rs
+++ b/src/thin/delta_visitor.rs
@@ -5,7 +5,6 @@ use quick_xml::events::{BytesEnd, BytesStart, Event};
 use quick_xml::Writer;
 
 use crate::thin::ir::{self, Visit};
-use crate::thin::xml::XML_VERSION;
 use crate::xml::mk_attr;
 
 //------------------------------------------
@@ -346,7 +345,6 @@ fn write_superblock_b<W: Write>(w: &mut Writer<W>, sb: &ir::Superblock) -> Resul
         elem.push_attribute(mk_attr(b"flags", flags));
     }
 
-    elem.push_attribute(mk_attr(b"version", XML_VERSION));
     elem.push_attribute(mk_attr(b"data_block_size", sb.data_block_size));
     elem.push_attribute(mk_attr(b"nr_data_blocks", sb.nr_data_blocks));
 

--- a/src/thin/dump.rs
+++ b/src/thin/dump.rs
@@ -154,6 +154,7 @@ pub struct ThinDumpOptions<'a> {
     pub repair: bool,
     pub skip_mappings: bool,
     pub overrides: SuperblockOverrides,
+    pub selected_devs: Option<Vec<u64>>,
 }
 
 struct ThinDumpContext {
@@ -323,7 +324,7 @@ pub fn dump(opts: ThinDumpOptions) -> Result<()> {
     let md = if opts.skip_mappings {
         build_metadata_without_mappings(ctx.engine.clone(), &sb)?
     } else {
-        let m = build_metadata(ctx.engine.clone(), &sb)?;
+        let m = build_metadata_with_dev(ctx.engine.clone(), &sb, opts.selected_devs)?;
         optimise_metadata(m)?
     };
 

--- a/src/thin/dump.rs
+++ b/src/thin/dump.rs
@@ -270,7 +270,7 @@ pub fn dump_metadata(
         time: sb.time,
         transaction: sb.transaction_id,
         flags: if sb.flags.needs_check { Some(1) } else { None },
-        version: Some(2),
+        version: Some(sb.version),
         data_block_size: sb.data_block_size,
         nr_data_blocks: data_root.nr_blocks,
         metadata_snap: None,

--- a/src/thin/human_readable_format.rs
+++ b/src/thin/human_readable_format.rs
@@ -1,0 +1,97 @@
+use anyhow::Result;
+use std::io::Write;
+
+use crate::thin::ir::*;
+
+//---------------------------------------
+
+pub struct HumanReadableWriter<W: Write> {
+    w: W,
+}
+
+impl<W: Write> HumanReadableWriter<W> {
+    pub fn new(w: W) -> HumanReadableWriter<W> {
+        HumanReadableWriter { w }
+    }
+}
+
+const METADATA_VERSION: u32 = 2;
+
+impl<W: Write> MetadataVisitor for HumanReadableWriter<W> {
+    fn superblock_b(&mut self, sb: &Superblock) -> Result<Visit> {
+        write!(
+            self.w,
+            "begin superblock: \"{}\", {}, {}, {}, {}, {}, {}",
+            sb.uuid,
+            sb.time,
+            sb.transaction,
+            sb.flags.unwrap_or(0),
+            sb.version.unwrap_or(METADATA_VERSION),
+            sb.data_block_size,
+            sb.nr_data_blocks
+        )?;
+
+        if let Some(b) = sb.metadata_snap {
+            writeln!(self.w, ", {}", b)?;
+        } else {
+            self.w.write_all(b"\n")?;
+        }
+
+        Ok(Visit::Continue)
+    }
+
+    fn superblock_e(&mut self) -> Result<Visit> {
+        self.w.write_all(b"end superblock\n")?;
+        Ok(Visit::Continue)
+    }
+
+    fn def_shared_b(&mut self, name: &str) -> Result<Visit> {
+        writeln!(self.w, "def: {}", name)?;
+        Ok(Visit::Continue)
+    }
+
+    fn def_shared_e(&mut self) -> Result<Visit> {
+        self.w.write_all(b"\n")?;
+        Ok(Visit::Continue)
+    }
+
+    fn device_b(&mut self, d: &Device) -> Result<Visit> {
+        // The words "mapped_blocks" is connected by an underscore for backward compatibility.
+        writeln!(
+            self.w,
+            "device: {}\nmapped_blocks: {}\ntransaction: {}\ncreation time: {}\nsnap time: {}",
+            d.dev_id, d.mapped_blocks, d.transaction, d.creation_time, d.snap_time
+        )?;
+        Ok(Visit::Continue)
+    }
+
+    fn device_e(&mut self) -> Result<Visit> {
+        self.w.write_all(b"\n")?;
+        Ok(Visit::Continue)
+    }
+
+    fn map(&mut self, m: &Map) -> Result<Visit> {
+        writeln!(
+            self.w,
+            "    ({}..{}) -> ({}..{}), {}",
+            m.thin_begin,
+            m.thin_begin + m.len - 1,
+            m.data_begin,
+            m.data_begin + m.len - 1,
+            m.time
+        )?;
+        Ok(Visit::Continue)
+    }
+
+    fn ref_shared(&mut self, name: &str) -> Result<Visit> {
+        writeln!(self.w, "    ref: {}", name)?;
+        Ok(Visit::Continue)
+    }
+
+    fn eof(&mut self) -> Result<Visit> {
+        self.w.flush()?;
+        Ok(Visit::Continue)
+    }
+}
+
+//---------------------------------------

--- a/src/thin/mod.rs
+++ b/src/thin/mod.rs
@@ -4,6 +4,7 @@ pub mod delta;
 pub mod delta_visitor;
 pub mod device_detail;
 pub mod dump;
+pub mod human_readable_format;
 pub mod ir;
 pub mod ls;
 pub mod metadata;

--- a/src/thin/xml.rs
+++ b/src/thin/xml.rs
@@ -21,7 +21,7 @@ impl<W: Write> XmlWriter<W> {
     }
 }
 
-pub const XML_VERSION: u32 = 2;
+const METADATA_VERSION: u32 = 2;
 
 impl<W: Write> MetadataVisitor for XmlWriter<W> {
     fn superblock_b(&mut self, sb: &Superblock) -> Result<Visit> {
@@ -35,7 +35,7 @@ impl<W: Write> MetadataVisitor for XmlWriter<W> {
             elem.push_attribute(mk_attr(b"flags", flags));
         }
 
-        elem.push_attribute(mk_attr(b"version", XML_VERSION));
+        elem.push_attribute(mk_attr(b"version", sb.version.unwrap_or(METADATA_VERSION)));
         elem.push_attribute(mk_attr(b"data_block_size", sb.data_block_size));
         elem.push_attribute(mk_attr(b"nr_data_blocks", sb.nr_data_blocks));
 

--- a/src/units.rs
+++ b/src/units.rs
@@ -78,7 +78,7 @@ impl FromStr for Units {
             "sector" | "s" => Ok(Units::Sector),
             // base 2
             "kibibyte" | "KiB" | "k" => Ok(Units::Kibibyte),
-            "mibibyte" | "MiB" | "m" => Ok(Units::Mebibyte),
+            "mebibyte" | "MiB" | "m" => Ok(Units::Mebibyte),
             "gibibyte" | "GiB" | "g" => Ok(Units::Gibibyte),
             "tebibyte" | "TiB" | "t" => Ok(Units::Tebibyte),
             "pebibyte" | "PiB" | "p" => Ok(Units::Pebibyte),
@@ -104,7 +104,7 @@ impl ToString for Units {
             Sector => "sector",
             // base 2
             Kibibyte => "kibibyte",
-            Mebibyte => "mibibyte",
+            Mebibyte => "mebibyte",
             Gibibyte => "gibibyte",
             Tebibyte => "terabyte",
             Pebibyte => "pebibyte",

--- a/src/units.rs
+++ b/src/units.rs
@@ -67,6 +67,31 @@ impl Units {
             Exabyte => "EB",
         })
     }
+
+    pub fn to_letter(&self) -> String {
+        use Units::*;
+
+        // In order to maintain backward compatibilities, we use uppercase letters
+        // to denote decimal prefixes.
+        String::from(match self {
+            Byte => "b",
+            Sector => "s",
+            // letters for binary prefixes
+            Kibibyte => "k",
+            Mebibyte => "m",
+            Gibibyte => "g",
+            Tebibyte => "t",
+            Pebibyte => "p",
+            Exbibyte => "e",
+            // letters for decimal prefixes
+            Kilobyte => "K",
+            Megabyte => "M",
+            Gigabyte => "G",
+            Terabyte => "T",
+            Petabyte => "P",
+            Exabyte => "E",
+        })
+    }
 }
 
 impl FromStr for Units {

--- a/tests/cache_check.rs
+++ b/tests/cache_check.rs
@@ -32,7 +32,7 @@ OPTIONS:
     -q, --quiet                      Suppress output messages, return only exit code.
         --skip-discards              Don't check the discard bitset
         --skip-hints                 Don't check the hint array
-        --skip-mappings              Don't check the mapping tree
+        --skip-mappings              Don't check the mapping array
         --super-block-only           Only check the superblock
     -V, --version                    Print version information"
 );
@@ -103,6 +103,51 @@ test_spot_xml_data!(CacheCheck);
 test_corrupted_input_data!(CacheCheck);
 
 test_readonly_input_file!(CacheCheck);
+
+//------------------------------------------
+// test exclusive flags
+
+fn accepts_flag(flag: &str) -> Result<()> {
+    let mut td = TestDir::new()?;
+    let md = mk_valid_md(&mut td)?;
+    run_ok(cache_check_cmd(args![flag, &md]))?;
+    Ok(())
+}
+
+#[test]
+fn accepts_superblock_only() -> Result<()> {
+    accepts_flag("--super-block-only")
+}
+
+#[test]
+fn accepts_skip_mappings() -> Result<()> {
+    accepts_flag("--skip-mappings")
+}
+
+#[test]
+fn accepts_skip_hints() -> Result<()> {
+    accepts_flag("--skip-hints")
+}
+
+#[test]
+fn accepts_skip_discards() -> Result<()> {
+    accepts_flag("--skip-discards")
+}
+
+#[test]
+fn accepts_ignore_non_fatal_errors() -> Result<()> {
+    accepts_flag("--ignore-non-fatal-errors")
+}
+
+#[test]
+fn accepts_clear_needs_check_flag() -> Result<()> {
+    accepts_flag("--clear-needs-check-flag")
+}
+
+#[test]
+fn accepts_auto_repair() -> Result<()> {
+    accepts_flag("--auto-repair")
+}
 
 //------------------------------------------
 

--- a/tests/cache_metadata_size.rs
+++ b/tests/cache_metadata_size.rs
@@ -22,7 +22,7 @@ OPTIONS:
         --device-size <SIZE[bskmgtp]>    Specify total size of the fast device used in the cache
     -h, --help                           Print help information
         --max-hint-width <BYTES>         Specity the per-block hint width [default: 4]
-    -n, --numeric-only                   Output numeric value only
+    -n, --numeric-only[=<OPT>...]        Output numeric value only
         --nr-blocks <NUM>                Specify the number of cache blocks
     -u, --unit <UNIT>                    Specify the output unit in {bskKmMgG} [default: sector]
     -V, --version                        Print version information"

--- a/tests/cache_restore.rs
+++ b/tests/cache_restore.rs
@@ -144,28 +144,6 @@ fn successfully_restores() -> Result<()> {
     Ok(())
 }
 
-// FIXME: finish
-/*
-#[test]
-fn override_metadata_version() -> Result<()> {
-    let mut td = TestDir::new()?;
-    let xml = mk_valid_xml(&mut td)?;
-    let md = mk_zeroed_md(&mut td)?;
-    run_ok(
-        cache_restore_cmd(
-        args![
-            "-i",
-            &xml,
-            "-o",
-            &md,
-            "--debug-override-metadata-version",
-            "10298"
-        ],
-    ))?;
-    Ok(())
-}
-*/
-
 #[test]
 fn omit_clean_shutdown() -> Result<()> {
     let mut td = TestDir::new()?;

--- a/tests/era_check.rs
+++ b/tests/era_check.rs
@@ -100,6 +100,26 @@ test_corrupted_input_data!(EraCheck);
 test_readonly_input_file!(EraCheck);
 
 //------------------------------------------
+// test exclusive flags
+
+fn accepts_flag(flag: &str) -> Result<()> {
+    let mut td = TestDir::new()?;
+    let md = mk_valid_md(&mut td)?;
+    run_ok(era_check_cmd(args![flag, &md]))?;
+    Ok(())
+}
+
+#[test]
+fn accepts_superblock_only() -> Result<()> {
+    accepts_flag("--super-block-only")
+}
+
+#[test]
+fn accepts_ignore_non_fatal_errors() -> Result<()> {
+    accepts_flag("--ignore-non-fatal-errors")
+}
+
+//------------------------------------------
 
 #[test]
 fn failing_q() -> Result<()> {

--- a/tests/thin_dump.rs
+++ b/tests/thin_dump.rs
@@ -28,6 +28,7 @@ ARGS:
 
 OPTIONS:
         --data-block-size <SECTORS>       Provide the data block size for repairing
+        --dev-id <THIN_ID>                Dump the specified device
     -h, --help                            Print help information
     -m, --metadata-snap[=<BLOCKNR>...]    Access the metadata snapshot on a live pool
         --nr-data-blocks <NUM>            Override the number of data blocks if needed

--- a/tests/thin_dump.rs
+++ b/tests/thin_dump.rs
@@ -29,6 +29,7 @@ ARGS:
 OPTIONS:
         --data-block-size <SECTORS>       Provide the data block size for repairing
         --dev-id <THIN_ID>                Dump the specified device
+    -f, --format <TYPE>                   Choose the output format
     -h, --help                            Print help information
     -m, --metadata-snap[=<BLOCKNR>...]    Access the metadata snapshot on a live pool
         --nr-data-blocks <NUM>            Override the number of data blocks if needed

--- a/tests/thin_metadata_size.rs
+++ b/tests/thin_metadata_size.rs
@@ -21,7 +21,7 @@ OPTIONS:
     -b, --block-size <SIZE[bskmg]>     Specify the data block size
     -h, --help                         Print help information
     -m, --max-thins <NUM>              Maximum number of thin devices and snapshots
-    -n, --numeric-only                 Output numeric value only
+    -n, --numeric-only[=<OPT>...]      Output numeric value only
     -s, --pool-size <SIZE[bskmgtp]>    Specify the size of pool device
     -u, --unit <UNIT>                  Specify the output unit in {bskKmMgG} [default: sector]
     -V, --version                      Print version information"

--- a/tests/thin_shrink.rs
+++ b/tests/thin_shrink.rs
@@ -361,7 +361,7 @@ where
     test_shrink_(scenario, false)
 }
 
-fn test_shrink_binary_<S>(scenario: &mut S, expect_ok: bool) -> Result<()>
+fn test_shrink_in_binary_<S>(scenario: &mut S, expect_ok: bool) -> Result<()>
 where
     S: Scenario + XmlGen,
 {
@@ -415,18 +415,18 @@ where
     Ok(())
 }
 
-fn test_shrink_binary<S>(scenario: &mut S) -> Result<()>
+fn test_shrink_in_binary<S>(scenario: &mut S) -> Result<()>
 where
     S: Scenario + XmlGen,
 {
-    test_shrink_binary_(scenario, true)
+    test_shrink_in_binary_(scenario, true)
 }
 
-fn test_shrink_binary_fail<S>(scenario: &mut S) -> Result<()>
+fn test_shrink_in_binary_fail<S>(scenario: &mut S) -> Result<()>
 where
     S: Scenario + XmlGen,
 {
-    test_shrink_binary_(scenario, false)
+    test_shrink_in_binary_(scenario, false)
 }
 
 //------------------------------------
@@ -490,39 +490,39 @@ fn shrink_insufficient_space() -> Result<()> {
 //------------------------------------
 
 #[test]
-fn shrink_binary_single_no_move_1() -> Result<()> {
+fn shrink_single_no_move_in_binary_1() -> Result<()> {
     let mut s = SingleThinS::new(0, 1024, 2048, 1280);
-    test_shrink_binary(&mut s)
+    test_shrink_in_binary(&mut s)
 }
 
 #[test]
-fn shrink_binary_single_no_move_2() -> Result<()> {
+fn shrink_single_no_move_in_binary_2() -> Result<()> {
     let mut s = SingleThinS::new(100, 1024, 2048, 1280);
-    test_shrink_binary(&mut s)
+    test_shrink_in_binary(&mut s)
 }
 
 #[test]
-fn shrink_binary_single_no_move_3() -> Result<()> {
+fn shrink_single_no_move_in_binary_3() -> Result<()> {
     let mut s = SingleThinS::new(1024, 1024, 2048, 2048);
-    test_shrink_binary(&mut s)
+    test_shrink_in_binary(&mut s)
 }
 
 #[test]
-fn shrink_binary_single_partial_move() -> Result<()> {
+fn shrink_single_partial_move_in_binary() -> Result<()> {
     let mut s = SingleThinS::new(1024, 1024, 2048, 1280);
-    test_shrink_binary(&mut s)
+    test_shrink_in_binary(&mut s)
 }
 
 #[test]
-fn shrink_binary_single_total_move() -> Result<()> {
+fn shrink_single_total_move_in_binary() -> Result<()> {
     let mut s = SingleThinS::new(2048, 1024, 1024 + 2048, 1280);
-    test_shrink_binary(&mut s)
+    test_shrink_in_binary(&mut s)
 }
 
 #[test]
-fn shrink_binary_insufficient_space() -> Result<()> {
+fn shrink_insufficient_space_in_binary() -> Result<()> {
     let mut s = SingleThinS::new(0, 2048, 3000, 1280);
-    test_shrink_binary_fail(&mut s)
+    test_shrink_in_binary_fail(&mut s)
 }
 
 //------------------------------------
@@ -560,27 +560,27 @@ fn shrink_fragmented_thin_64() -> Result<()> {
 //------------------------------------
 
 #[test]
-fn shrink_binary_fragmented_thin_1() -> Result<()> {
+fn shrink_fragmented_thin_1_in_binary() -> Result<()> {
     let mut s = FragmentedS::new(1, 2048);
-    test_shrink_binary(&mut s)
+    test_shrink_in_binary(&mut s)
 }
 
 #[test]
-fn shrink_binary_fragmented_thin_2() -> Result<()> {
+fn shrink_fragmented_thin_2_in_binary() -> Result<()> {
     let mut s = FragmentedS::new(2, 2048);
-    test_shrink_binary(&mut s)
+    test_shrink_in_binary(&mut s)
 }
 
 #[test]
-fn shrink_binary_fragmented_thin_8() -> Result<()> {
+fn shrink_fragmented_thin_8_in_binary() -> Result<()> {
     let mut s = FragmentedS::new(8, 2048);
-    test_shrink_binary(&mut s)
+    test_shrink_in_binary(&mut s)
 }
 
 #[test]
-fn shrink_binary_fragmented_thin_64() -> Result<()> {
+fn shrink_fragmented_thin_64_in_binary() -> Result<()> {
     let mut s = FragmentedS::new(64, 2048);
-    test_shrink_binary(&mut s)
+    test_shrink_in_binary(&mut s)
 }
 
 //------------------------------------
@@ -636,7 +636,7 @@ fn shrink_multiple_snaps() -> Result<()> {
 
 // Using the pre-generated packed metadata
 #[test]
-fn shrink_binary_multiple_snaps() -> Result<()> {
+fn shrink_multiple_snaps_in_binary() -> Result<()> {
     let mut td = TestDir::new()?;
     let meta_before = prep_rebuilt_metadata(&mut td)?;
     let xml_before = td.mk_path("before.xml");


### PR DESCRIPTION
- Implemented missing features
  - Added `thin_dump --dev-id`
  - Added `thin_dump --format={xml|human_readable}`, and implemented the human readable format.
- Improve backward compatibility
  - Make the `--numeric-only` option in thin_metadata_size backward compatible
- Bug fixes and tidying
  - Fix false-alarm in cache_check
  - Correct the version number in thin_dump