### PR TITLE
thin_check minor fixes

### DIFF
--- a/doc/TODO.md
+++ b/doc/TODO.md
@@ -54,6 +54,7 @@ Items in the High or Medium sections should be done before the formal release. T
 - [ ] Check the key ranges in BTreeWalker.
 - [ ] thin_check: improve error reporting on ref count tree checking (the "overflow" trees).
       Currently it dumps the BTreeError directly.
+- [ ] Parameterize IoEngine: Relies on ReadBlocks or WriteBlocks rather than concret File
 
 ## RFEs
 

--- a/src/cache/writeback.rs
+++ b/src/cache/writeback.rs
@@ -769,14 +769,14 @@ fn copy_selected_blocks(
 }
 
 fn report_stats(report: Arc<Report>, stats: &WritebackStats) {
-    report.info(&format!(
+    report.to_stdout(&format!(
         "{}/{} blocks successfully copied",
         stats.nr_copied, stats.nr_blocks
     ));
 
     let nr_errors = stats.nr_read_errors + stats.nr_write_errors;
     if nr_errors > 0 {
-        report.info(&format!("{} blocks were not copied", nr_errors));
+        report.fatal(&format!("{} blocks were not copied", nr_errors));
     }
 }
 
@@ -798,9 +798,9 @@ pub fn writeback(opts: CacheWritebackOptions) -> anyhow::Result<()> {
     match copy_dirty_blocks(&ctx, &sb, &opts) {
         Err(e) => {
             ctx.report
-                .info("Metadata corruption was found, some data may not have been copied.");
+                .fatal("Metadata corruption was found, some data may not have been copied.");
             if opts.update_metadata {
-                ctx.report.info("Unable to update metadata");
+                ctx.report.fatal("Unable to update metadata");
             }
             return Err(anyhow!("Metadata contains errors, reason: {}", e));
         }

--- a/src/commands/cache_restore.rs
+++ b/src/commands/cache_restore.rs
@@ -7,6 +7,7 @@ use crate::cache::restore::{restore, CacheRestoreOptions};
 use crate::commands::engine::*;
 use crate::commands::utils::*;
 use crate::commands::Command;
+use crate::report::{parse_log_level, verbose_args};
 
 pub struct CacheRestoreCommand;
 
@@ -52,7 +53,7 @@ impl CacheRestoreCommand {
                     .value_name("FILE")
                     .required(true),
             );
-        engine_args(cmd)
+        verbose_args(engine_args(cmd))
     }
 }
 
@@ -68,6 +69,12 @@ impl<'a> Command<'a> for CacheRestoreCommand {
         let output_file = Path::new(matches.value_of("OUTPUT").unwrap());
 
         let report = mk_report(matches.is_present("QUIET"));
+        let log_level = match parse_log_level(&matches) {
+            Ok(level) => level,
+            Err(e) => return to_exit_code::<()>(&report, Err(anyhow::Error::msg(e))),
+        };
+        report.set_level(log_level);
+
         check_input_file(input_file, &report);
         check_output_file(output_file, &report);
 

--- a/src/commands/era_check.rs
+++ b/src/commands/era_check.rs
@@ -1,10 +1,7 @@
 extern crate clap;
 
-use atty::Stream;
 use clap::Arg;
 use std::path::Path;
-
-use std::sync::Arc;
 
 use crate::commands::engine::*;
 use crate::commands::utils::*;
@@ -46,7 +43,7 @@ impl EraCheckCommand {
                     .required(true)
                     .index(1),
             );
-        engine_args(cmd)
+        verbose_args(engine_args(cmd))
     }
 }
 
@@ -60,13 +57,12 @@ impl<'a> Command<'a> for EraCheckCommand {
 
         let input_file = Path::new(matches.value_of("INPUT").unwrap());
 
-        let report = if matches.is_present("QUIET") {
-            std::sync::Arc::new(mk_quiet_report())
-        } else if atty::is(Stream::Stdout) {
-            std::sync::Arc::new(mk_progress_bar_report())
-        } else {
-            Arc::new(mk_simple_report())
+        let report = mk_report(matches.is_present("QUIET"));
+        let log_level = match parse_log_level(&matches) {
+            Ok(level) => level,
+            Err(e) => return to_exit_code::<()>(&report, Err(anyhow::Error::msg(e))),
         };
+        report.set_level(log_level);
 
         check_input_file(input_file, &report);
         check_file_not_tiny(input_file, &report);

--- a/src/commands/era_dump.rs
+++ b/src/commands/era_dump.rs
@@ -63,9 +63,8 @@ impl<'a> Command<'a> for EraDumpCommand {
             None
         };
 
-        // Create a temporary report just in case these checks
-        // need to report anything.
         let report = std::sync::Arc::new(crate::report::mk_simple_report());
+
         check_input_file(input_file, &report);
         check_file_not_tiny(input_file, &report);
 

--- a/src/commands/era_repair.rs
+++ b/src/commands/era_repair.rs
@@ -1,10 +1,7 @@
 extern crate clap;
 
-use atty::Stream;
 use clap::Arg;
 use std::path::Path;
-
-use std::sync::Arc;
 
 use crate::commands::engine::*;
 use crate::commands::utils::*;
@@ -43,7 +40,7 @@ impl EraRepairCommand {
                     .value_name("FILE")
                     .required(true),
             );
-        engine_args(cmd)
+        verbose_args(engine_args(cmd))
     }
 }
 
@@ -58,13 +55,12 @@ impl<'a> Command<'a> for EraRepairCommand {
         let input_file = Path::new(matches.value_of("INPUT").unwrap());
         let output_file = Path::new(matches.value_of("OUTPUT").unwrap());
 
-        let report = if matches.is_present("QUIET") {
-            std::sync::Arc::new(mk_quiet_report())
-        } else if atty::is(Stream::Stdout) {
-            std::sync::Arc::new(mk_progress_bar_report())
-        } else {
-            Arc::new(mk_simple_report())
+        let report = mk_report(matches.is_present("QUIET"));
+        let log_level = match parse_log_level(&matches) {
+            Ok(level) => level,
+            Err(e) => return to_exit_code::<()>(&report, Err(anyhow::Error::msg(e))),
         };
+        report.set_level(log_level);
 
         check_input_file(input_file, &report);
 

--- a/src/commands/era_restore.rs
+++ b/src/commands/era_restore.rs
@@ -7,6 +7,7 @@ use crate::commands::engine::*;
 use crate::commands::utils::*;
 use crate::commands::Command;
 use crate::era::restore::{restore, EraRestoreOptions};
+use crate::report::{parse_log_level, verbose_args};
 
 pub struct EraRestoreCommand;
 
@@ -40,7 +41,7 @@ impl EraRestoreCommand {
                     .value_name("FILE")
                     .required(true),
             );
-        engine_args(cmd)
+        verbose_args(engine_args(cmd))
     }
 }
 
@@ -56,6 +57,12 @@ impl<'a> Command<'a> for EraRestoreCommand {
         let output_file = Path::new(matches.value_of("OUTPUT").unwrap());
 
         let report = mk_report(matches.is_present("QUIET"));
+        let log_level = match parse_log_level(&matches) {
+            Ok(level) => level,
+            Err(e) => return to_exit_code::<()>(&report, Err(anyhow::Error::msg(e))),
+        };
+        report.set_level(log_level);
+
         check_input_file(input_file, &report);
         check_output_file(output_file, &report);
 

--- a/src/commands/thin_repair.rs
+++ b/src/commands/thin_repair.rs
@@ -6,6 +6,7 @@ use std::path::Path;
 use crate::commands::engine::*;
 use crate::commands::utils::*;
 use crate::commands::Command;
+use crate::report::{parse_log_level, verbose_args};
 use crate::thin::metadata_repair::SuperblockOverrides;
 use crate::thin::repair::{repair, ThinRepairOptions};
 
@@ -58,7 +59,7 @@ impl ThinRepairCommand {
                     .long("transaction-id")
                     .value_name("NUM"),
             );
-        engine_args(cmd)
+        verbose_args(engine_args(cmd))
     }
 }
 
@@ -74,6 +75,12 @@ impl<'a> Command<'a> for ThinRepairCommand {
         let output_file = Path::new(matches.value_of("OUTPUT").unwrap());
 
         let report = mk_report(matches.is_present("QUIET"));
+        let log_level = match parse_log_level(&matches) {
+            Ok(level) => level,
+            Err(e) => return to_exit_code::<()>(&report, Err(anyhow::Error::msg(e))),
+        };
+        report.set_level(log_level);
+
         check_input_file(input_file, &report);
         check_output_file(output_file, &report);
 

--- a/src/commands/thin_restore.rs
+++ b/src/commands/thin_restore.rs
@@ -6,6 +6,7 @@ use std::path::Path;
 use crate::commands::engine::*;
 use crate::commands::utils::*;
 use crate::commands::Command;
+use crate::report::{parse_log_level, verbose_args};
 use crate::thin::metadata_repair::SuperblockOverrides;
 use crate::thin::restore::{restore, ThinRestoreOptions};
 
@@ -58,7 +59,7 @@ impl ThinRestoreCommand {
                     .long("transaction-id")
                     .value_name("NUM"),
             );
-        engine_args(cmd)
+        verbose_args(engine_args(cmd))
     }
 }
 
@@ -74,6 +75,12 @@ impl<'a> Command<'a> for ThinRestoreCommand {
         let output_file = Path::new(matches.value_of("OUTPUT").unwrap());
 
         let report = mk_report(matches.is_present("QUIET"));
+        let log_level = match parse_log_level(&matches) {
+            Ok(level) => level,
+            Err(e) => return to_exit_code::<()>(&report, Err(anyhow::Error::msg(e))),
+        };
+        report.set_level(log_level);
+
         check_input_file(input_file, &report);
         check_output_file(output_file, &report);
 

--- a/src/commands/thin_trim.rs
+++ b/src/commands/thin_trim.rs
@@ -5,6 +5,7 @@ use std::path::Path;
 
 use crate::commands::engine::*;
 use crate::commands::utils::*;
+use crate::report::{parse_log_level, verbose_args};
 use crate::thin::trim::{trim, ThinTrimOptions};
 
 //------------------------------------------
@@ -39,7 +40,7 @@ impl ThinTrimCommand {
                     .value_name("FILE")
                     .required(true),
             );
-        engine_args(cmd)
+        verbose_args(engine_args(cmd))
     }
 }
 
@@ -55,6 +56,12 @@ impl<'a> Command<'a> for ThinTrimCommand {
         let data_dev = Path::new(matches.value_of("DATA_DEV").unwrap());
 
         let report = mk_report(matches.is_present("QUIET"));
+        let log_level = match parse_log_level(&matches) {
+            Ok(level) => level,
+            Err(e) => return to_exit_code::<()>(&report, Err(anyhow::Error::msg(e))),
+        };
+        report.set_level(log_level);
+
         check_input_file(metadata_dev, &report);
         check_input_file(data_dev, &report);
 

--- a/src/pdata/array.rs
+++ b/src/pdata/array.rs
@@ -92,9 +92,10 @@ pub enum ArrayError {
 
     //#[error("{0:?}, {1}")]
     Path(Vec<u64>, Box<ArrayError>),
-}
 
-impl btree_error::AnyError for ArrayError {}
+    #[error(transparent)]
+    BTreeError(#[from] btree_error::BTreeError),
+}
 
 impl fmt::Display for ArrayError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -113,6 +114,7 @@ impl fmt::Display for ArrayError {
                 Ok(())
             }
             ArrayError::Path(path, e) => write!(f, "{} {}", e, btree_error::encode_node_path(path)),
+            ArrayError::BTreeError(e) => write!(f, "{}", e),
         }
     }
 }

--- a/src/pdata/bitset.rs
+++ b/src/pdata/bitset.rs
@@ -5,7 +5,6 @@ use crate::io_engine::IoEngine;
 use crate::math::div_up;
 use crate::pdata::array::{self, ArrayBlock};
 use crate::pdata::array_walker::{ArrayVisitor, ArrayWalker};
-use crate::pdata::btree_error;
 use crate::pdata::space_map::*;
 
 //------------------------------------------
@@ -140,7 +139,7 @@ pub fn read_bitset_checked(
     root: u64,
     nr_bits: usize,
     ignore_none_fatal: bool,
-) -> (CheckedBitSet, Option<btree_error::BTreeError>) {
+) -> (CheckedBitSet, Option<array::ArrayError>) {
     let w = ArrayWalker::new(engine, ignore_none_fatal);
     let v = BitsetVisitor::new(nr_bits);
     let err = match w.walk(&v, root) {
@@ -157,7 +156,7 @@ pub fn read_bitset_checked_with_sm(
     nr_bits: usize,
     sm: Arc<Mutex<dyn SpaceMap + Send + Sync>>,
     ignore_none_fatal: bool,
-) -> array::Result<(CheckedBitSet, Option<btree_error::BTreeError>)> {
+) -> array::Result<(CheckedBitSet, Option<array::ArrayError>)> {
     let w = ArrayWalker::new_with_sm(engine, sm, ignore_none_fatal)?;
     let v = BitsetVisitor::new(nr_bits);
     let err = match w.walk(&v, root) {
@@ -172,7 +171,7 @@ pub fn read_bitset(
     root: u64,
     nr_bits: usize,
     ignore_none_fatal: bool,
-) -> btree_error::Result<FixedBitSet> {
+) -> array::Result<FixedBitSet> {
     let w = ArrayWalker::new(engine, ignore_none_fatal);
     let v = BitsetCollector::new(nr_bits);
     w.walk(&v, root)?;

--- a/src/pdata/btree_error.rs
+++ b/src/pdata/btree_error.rs
@@ -309,25 +309,6 @@ fn test_encode_path() {
 
 //------------------------------------------
 
-pub trait AnyError: BoxedClone + fmt::Debug {}
-
-// A helper trait that clones Boxed trait object
-pub trait BoxedClone {
-    fn boxed_clone(&self) -> Box<dyn AnyError + Send + Sync>;
-}
-
-impl<T: 'static + AnyError + Clone + Send + Sync> BoxedClone for T {
-    fn boxed_clone(&self) -> Box<dyn AnyError + Send + Sync> {
-        Box::new(self.clone())
-    }
-}
-
-impl Clone for Box<dyn AnyError + Send + Sync> {
-    fn clone(&self) -> Box<dyn AnyError + Send + Sync> {
-        self.boxed_clone()
-    }
-}
-
 #[derive(Error, Clone, Debug)]
 pub enum BTreeError {
     // #[error("io error")]
@@ -347,14 +328,6 @@ pub enum BTreeError {
 
     // #[error("{0:?}, {1}")]
     Path(Vec<u64>, Box<BTreeError>),
-
-    Other(Box<dyn AnyError + Send + Sync>),
-}
-
-impl<T: 'static + AnyError + Send + Sync> From<T> for BTreeError {
-    fn from(t: T) -> Self {
-        BTreeError::Other(Box::new(t))
-    }
 }
 
 impl fmt::Display for BTreeError {
@@ -371,7 +344,6 @@ impl fmt::Display for BTreeError {
                 Ok(())
             }
             BTreeError::Path(path, e) => write!(f, "{} {}", e, encode_node_path(path)),
-            BTreeError::Other(e) => write!(f, "{:?}", e),
         }
     }
 }

--- a/src/pdata/btree_walker.rs
+++ b/src/pdata/btree_walker.rs
@@ -219,15 +219,10 @@ impl BTreeWalker {
                 keys,
                 values,
             } => {
-                let ret = visitor.visit(path, kr, &header, &keys, &values);
-                match ret {
-                    Err(BTreeError::Aggregate(_)) => return ret,
-                    Err(e) => {
-                        let e = BTreeError::Path(path.clone(), Box::new(e)).keys_context(kr);
-                        self.set_fail(b.loc, e.clone());
-                        return Err(e);
-                    }
-                    _ => {}
+                if let Err(e) = visitor.visit(path, kr, &header, &keys, &values) {
+                    let e = BTreeError::Path(path.clone(), Box::new(e)).keys_context(kr);
+                    self.set_fail(b.loc, e.clone());
+                    return Err(e);
                 }
             }
         }

--- a/src/report.rs
+++ b/src/report.rs
@@ -251,7 +251,7 @@ impl ProgressMonitor {
 
         let stopped = stop_flag.clone();
         let tid = thread::spawn(move || {
-            let interval = std::time::Duration::from_millis(250);
+            let interval = std::time::Duration::from_millis(500);
             loop {
                 if stopped.load(Ordering::Relaxed) {
                     break;

--- a/src/report.rs
+++ b/src/report.rs
@@ -7,6 +7,66 @@ use std::thread::{self, JoinHandle};
 
 //------------------------------------------
 
+#[derive(Copy, Clone, Eq, PartialEq, PartialOrd)]
+pub enum LogLevel {
+    Fatal = 1,
+    Error,
+    Warning,
+    Info,
+    Debug,
+}
+
+impl TryFrom<u8> for LogLevel {
+    type Error = String;
+
+    fn try_from(level: u8) -> Result<LogLevel, <Self as TryFrom<u8>>::Error> {
+        match level {
+            0 => Err(String::from("invalid index")),
+            1 => Ok(LogLevel::Fatal),
+            2 => Ok(LogLevel::Error),
+            3 => Ok(LogLevel::Warning),
+            4 => Ok(LogLevel::Info),
+            5..=u8::MAX => Ok(LogLevel::Debug),
+        }
+    }
+}
+
+impl From<LogLevel> for u8 {
+    fn from(level: LogLevel) -> u8 {
+        match level {
+            LogLevel::Fatal => 1,
+            LogLevel::Error => 2,
+            LogLevel::Warning => 3,
+            LogLevel::Info => 4,
+            LogLevel::Debug => 5,
+        }
+    }
+}
+
+pub fn verbose_args(cmd: clap::Command) -> clap::Command {
+    use clap::Arg;
+
+    cmd.arg(
+        Arg::new("VERBOSE")
+            .help("Increase log verbosity")
+            .short('v')
+            .multiple_occurrences(true)
+            .hide(true),
+    )
+}
+
+pub fn parse_log_level(matches: &clap::ArgMatches) -> Result<LogLevel, String> {
+    let cnt = matches.occurrences_of("VERBOSE");
+    if cnt > 0 {
+        let v: u8 = LogLevel::Warning.into();
+        (v + cnt as u8).try_into()
+    } else {
+        Ok(LogLevel::Warning)
+    }
+}
+
+//------------------------------------------
+
 #[derive(Clone, PartialEq, Eq)]
 pub enum ReportOutcome {
     Success,
@@ -36,8 +96,9 @@ pub struct Report {
 pub trait ReportInner {
     fn set_title(&mut self, txt: &str);
     fn set_sub_title(&mut self, txt: &str);
+    fn set_level(&mut self, level: LogLevel);
     fn progress(&mut self, percent: u8);
-    fn log(&mut self, txt: &str);
+    fn log(&mut self, txt: &str, level: LogLevel);
     fn to_stdout(&mut self, txt: &str);
     fn complete(&mut self);
 }
@@ -65,6 +126,11 @@ impl Report {
         inner.set_sub_title(txt)
     }
 
+    pub fn set_level(&self, level: LogLevel) {
+        let mut inner = self.inner.lock().unwrap();
+        inner.set_level(level)
+    }
+
     pub fn progress(&self, percent: u8) {
         let mut inner = self.inner.lock().unwrap();
         inner.progress(percent)
@@ -72,19 +138,29 @@ impl Report {
 
     pub fn info(&self, txt: &str) {
         let mut inner = self.inner.lock().unwrap();
-        inner.log(txt)
+        inner.log(txt, LogLevel::Info)
+    }
+
+    pub fn debug(&self, txt: &str) {
+        let mut inner = self.inner.lock().unwrap();
+        inner.log(txt, LogLevel::Debug)
+    }
+
+    pub fn warning(&self, txt: &str) {
+        let mut inner = self.inner.lock().unwrap();
+        inner.log(txt, LogLevel::Warning)
     }
 
     pub fn non_fatal(&self, txt: &str) {
         self.update_outcome(NonFatal);
         let mut inner = self.inner.lock().unwrap();
-        inner.log(txt)
+        inner.log(txt, LogLevel::Error)
     }
 
     pub fn fatal(&self, txt: &str) {
         self.update_outcome(Fatal);
         let mut inner = self.inner.lock().unwrap();
-        inner.log(txt)
+        inner.log(txt, LogLevel::Fatal)
     }
 
     pub fn complete(&mut self) {
@@ -110,6 +186,7 @@ impl Report {
 #[allow(dead_code)]
 struct PBInner {
     bar: ProgressBar,
+    level: LogLevel,
 }
 
 impl PBInner {
@@ -121,7 +198,10 @@ impl PBInner {
                 .template(&fmt)
                 .progress_chars("=> "),
         );
-        Self { bar }
+        Self {
+            bar,
+            level: LogLevel::Warning,
+        }
     }
 }
 
@@ -146,13 +226,19 @@ impl ReportInner for PBInner {
         self.bar.set_message(msg);
     }
 
+    fn set_level(&mut self, level: LogLevel) {
+        self.level = level;
+    }
+
     fn progress(&mut self, percent: u8) {
         self.bar.set_position(percent as u64);
         self.bar.tick();
     }
 
-    fn log(&mut self, txt: &str) {
-        self.bar.println(txt);
+    fn log(&mut self, txt: &str, level: LogLevel) {
+        if level <= self.level {
+            self.bar.println(txt);
+        }
     }
 
     fn to_stdout(&mut self, txt: &str) {
@@ -172,12 +258,14 @@ pub fn mk_progress_bar_report() -> Report {
 
 struct SimpleInner {
     last_progress: std::time::SystemTime,
+    level: LogLevel,
 }
 
 impl SimpleInner {
     fn new() -> SimpleInner {
         SimpleInner {
             last_progress: std::time::SystemTime::now(),
+            level: LogLevel::Warning,
         }
     }
 }
@@ -191,6 +279,10 @@ impl ReportInner for SimpleInner {
         eprintln!("{}", txt);
     }
 
+    fn set_level(&mut self, level: LogLevel) {
+        self.level = level;
+    }
+
     fn progress(&mut self, percent: u8) {
         let elapsed = self.last_progress.elapsed().unwrap();
         if elapsed > std::time::Duration::from_secs(5) {
@@ -199,8 +291,10 @@ impl ReportInner for SimpleInner {
         }
     }
 
-    fn log(&mut self, txt: &str) {
-        eprintln!("{}", txt);
+    fn log(&mut self, txt: &str, level: LogLevel) {
+        if level <= self.level {
+            eprintln!("{}", txt);
+        }
     }
 
     fn to_stdout(&mut self, txt: &str) {
@@ -223,9 +317,12 @@ impl ReportInner for QuietInner {
 
     fn set_sub_title(&mut self, _txt: &str) {}
 
+    fn set_level(&mut self, _level: LogLevel) {}
+
     fn progress(&mut self, _percent: u8) {}
 
-    fn log(&mut self, _txt: &str) {}
+    fn log(&mut self, _txt: &str, _level: LogLevel) {}
+
     fn to_stdout(&mut self, _txt: &str) {}
 
     fn complete(&mut self) {}

--- a/src/thin/check.rs
+++ b/src/thin/check.rs
@@ -433,10 +433,14 @@ fn summarize_tree(
                     return NodeSummary::default();
                 }
 
-                // Gather information from the children
-                // FIXME: handle key range mismatch on internal nodes
-                let child_keys = split_key_ranges(path, kr, &info.keys).unwrap();
+                // Split up the key range for the children.
+                // Return immediately if the keys don't match.
+                let child_keys = match split_key_ranges(path, kr, &info.keys) {
+                    Ok(keys) => keys,
+                    Err(_) => return NodeSummary::default(),
+                };
 
+                // Gather information from the children
                 let mut sum = NodeSummary::default();
                 for (i, b) in info.children.iter().enumerate() {
                     path.push(*b as u64);

--- a/src/thin/check.rs
+++ b/src/thin/check.rs
@@ -830,13 +830,14 @@ pub fn check(opts: ThinCheckOptions) -> Result<()> {
             all_roots.push(*root);
         });
 
-        // The exclusive thins are selected by the root block address with the
-        // concerns thin id reuse.
-        // Note that the two sets might not have identical thins before filtering
+        // Leave the thins that are exclusive to metadata snapshot.
+        // Considering thin id reuse, the exclusive thins are those whose subtrees
+        // are not used by the current superblock.
+        // Note that the two maps might not have identical thins before filtering
         // due to their different value sizes.
         let roots_snap: BTreeMap<u64, u64> = roots_snap
             .into_iter()
-            .filter(|(_thin_id, root)| roots.iter().any(|(_id, (_p, r))| root == r))
+            .filter(|(_thin_id, root)| !roots.iter().any(|(_id, (_p, r))| root == r))
             .collect();
         let devs_snap: BTreeMap<u64, DeviceDetail> = devs_snap
             .into_iter()

--- a/src/thin/check.rs
+++ b/src/thin/check.rs
@@ -487,19 +487,19 @@ fn check_mapping_bottom_level(
     let nodes = collect_nodes_in_use(ctx, metadata_sm, roots, ignore_non_fatal);
     let duration = start.elapsed();
     ctx.report
-        .info(&format!("reading internal nodes: {:?}", duration));
+        .debug(&format!("reading internal nodes: {:?}", duration));
 
     let start = std::time::Instant::now();
     let (nodes, mut summaries) = read_leaf_nodes(ctx, nodes, data_sm, ignore_non_fatal);
     let duration = start.elapsed();
     ctx.report
-        .info(&format!("reading leaf nodes: {:?}", duration));
+        .debug(&format!("reading leaf nodes: {:?}", duration));
 
     let start = std::time::Instant::now();
     count_mapped_blocks(roots, &nodes, &mut summaries, ignore_non_fatal);
     let duration = start.elapsed();
     ctx.report
-        .info(&format!("counting mapped blocks: {:?}", duration));
+        .debug(&format!("counting mapped blocks: {:?}", duration));
 
     ctx.report
         .info(&format!("nr internal nodes: {}", nodes.internal_info.len()));
@@ -651,7 +651,7 @@ fn check_mapped_blocks(
     }
     let duration = start.elapsed();
     ctx.report
-        .info(&format!("checking mapped blocks: {:?}", duration));
+        .debug(&format!("checking mapped blocks: {:?}", duration));
 
     if failed {
         Err(anyhow!("Check of mappings failed"))
@@ -919,7 +919,7 @@ pub fn check(opts: ThinCheckOptions) -> Result<()> {
     )?;
     let duration = start.elapsed();
     ctx.report
-        .info(&format!("checking data space map: {:?}", duration));
+        .debug(&format!("checking data space map: {:?}", duration));
 
     //-----------------------------------------
 
@@ -937,7 +937,7 @@ pub fn check(opts: ThinCheckOptions) -> Result<()> {
     )?;
     let duration = start.elapsed();
     ctx.report
-        .info(&format!("checking metadata space map: {:?}", duration));
+        .debug(&format!("checking metadata space map: {:?}", duration));
 
     //-----------------------------------------
 


### PR DESCRIPTION
thin_check:
- Check key range mismatch between internal nodes
- Fix device selection for metadata snap checking
- Fix progress bar positioning
- Check blocknr in btree node header

Others:
- Simplify error representation for arrays
- Enable log levels