### PR TITLE
Fix metadata snapshot option in a few places

### DIFF
--- a/src/commands/era_invalidate.rs
+++ b/src/commands/era_invalidate.rs
@@ -19,7 +19,7 @@ impl EraInvalidateCommand {
             .version(crate::version::tools_version())
             .about("List blocks that may have changed since a given era")
             .arg(
-                Arg::new("METADATA_SNAP")
+                Arg::new("METADATA_SNAPSHOT")
                     .help("Use the metadata snapshot rather than the current superblock")
                     .long("metadata-snapshot"),
             )

--- a/src/commands/thin_delta.rs
+++ b/src/commands/thin_delta.rs
@@ -20,7 +20,7 @@ impl ThinDeltaCommand {
             .version(crate::version::tools_version())
             .about("Print the differences in the mappings between two thin devices")
             .arg(
-                Arg::new("METADATA_SNAP")
+                Arg::new("METADATA_SNAPSHOT")
                     .help("Use metadata snapshot")
                     .short('m')
                     .long("metadata-snap"),

--- a/src/commands/thin_ls.rs
+++ b/src/commands/thin_ls.rs
@@ -23,7 +23,7 @@ impl ThinLsCommand {
                     .long("no-headers"),
             )
             .arg(
-                Arg::new("METADATA_SNAP")
+                Arg::new("METADATA_SNAPSHOT")
                     .help("Use metadata snapshot")
                     .short('m')
                     .long("metadata-snap"),

--- a/src/era/invalidate.rs
+++ b/src/era/invalidate.rs
@@ -241,7 +241,7 @@ struct Context {
 
 fn mk_context(opts: &EraInvalidateOptions) -> anyhow::Result<Context> {
     let engine = EngineBuilder::new(opts.input, &opts.engine_opts)
-        .write(true)
+        .exclusive(!opts.engine_opts.use_metadata_snap)
         .build()?;
     Ok(Context { engine })
 }

--- a/src/thin/check.rs
+++ b/src/thin/check.rs
@@ -821,6 +821,7 @@ fn mk_context_(engine: Arc<dyn IoEngine + Send + Sync>, report: Arc<Report>) -> 
 fn mk_context(opts: &ThinCheckOptions) -> Result<Context> {
     let engine = EngineBuilder::new(opts.input, &opts.engine_opts)
         .write(opts.auto_repair || opts.clear_needs_check)
+        .exclusive(!opts.engine_opts.use_metadata_snap)
         .build()?;
     mk_context_(engine, opts.report.clone())
 }

--- a/src/thin/dump.rs
+++ b/src/thin/dump.rs
@@ -183,7 +183,9 @@ struct ThinDumpContext {
 }
 
 fn mk_context(opts: &ThinDumpOptions) -> Result<ThinDumpContext> {
-    let engine = EngineBuilder::new(opts.input, &opts.engine_opts).build()?;
+    let engine = EngineBuilder::new(opts.input, &opts.engine_opts)
+        .exclusive(!opts.engine_opts.use_metadata_snap)
+        .build()?;
 
     Ok(ThinDumpContext {
         report: opts.report.clone(),


### PR DESCRIPTION
This PR fixes two issues:
- Some commands (`era_invalidate`, `thin_delta` and `thin_ls`) used the wrong arg name for the `--metadata-snap` option - it should be `METADATA_SNAPSHOT` in order to be picked up by `commands::engine::parse_engine_opts`
- Some command implementations (`era::invalidate`, `thin::check` and `thin::dump`) don't correctly call `exclusive()` based on whether a metadata snapshot is being used

For the setting of `exclusive()` I reverted to usage C++ codebase's `open_bm()` function. (I'm not familiar particularly with dm-era).

I hope this is the correct behaviour!