### PR TITLE
Fix incorrect crc32c outputs on big endian targets

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -125,8 +125,7 @@ dependencies = [
 [[package]]
 name = "crc32c"
 version = "0.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3dfea2db42e9927a3845fb268a10a72faed6d416065f77873f05e411457c363e"
+source = "git+https://github.com/zowens/crc32c?rev=refs/pull/35/head#4e362a4b57cf9e267f23dbe1d8b75790f802294e"
 dependencies = [
  "rustc_version",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ anyhow = "1.0"
 base64 = "0.20"
 byteorder = "1.4"
 clap = "3.2"
-crc32c = "0.6"
+crc32c = { git = "https://github.com/zowens/crc32c", rev="refs/pull/35/head" }
 data-encoding = "2.3"
 exitcode = "1.1.2"
 fixedbitset = "0.4"

--- a/src/cache/writeback.rs
+++ b/src/cache/writeback.rs
@@ -416,9 +416,9 @@ impl BitsetUpdater {
             let bit = b % BITS_PER_WORD;
 
             if v {
-                block.block.values[word as usize] |= 1 << bit;
+                block.block.values[word] |= 1 << bit;
             } else {
-                block.block.values[word as usize] &= !(1 << bit);
+                block.block.values[word] &= !(1 << bit);
             }
         } else {
             panic!("no current block (can't happen)");
@@ -535,7 +535,7 @@ fn update_v1_metadata(
     let mut needs_update = false;
 
     for cblock in cleaned_blocks.iter() {
-        if cblock as usize / max_entries as usize != index {
+        if cblock as usize / max_entries != index {
             if needs_update {
                 // update array block
                 let mut cursor = Cursor::new(b.get_data());
@@ -545,7 +545,7 @@ fn update_v1_metadata(
             }
 
             // move on to the new array block
-            index = cblock as usize / max_entries as usize;
+            index = cblock as usize / max_entries;
             b = ctx.engine.read(ablocks[index])?;
             ablock = unpack_array_block::<Mapping>(&path, b.get_data())?;
         }
@@ -734,7 +734,7 @@ fn copy_selected_blocks(
     report: Arc<Report>,
 ) -> anyhow::Result<(RoaringBitmap, RoaringBitmap, RoaringBitmap)> {
     let (tx, rx) = mpsc::sync_channel::<Vec<CopyOp>>(1);
-    let progress = Arc::new(ProgressReporter::new(report, blocks.len() as u64));
+    let progress = Arc::new(ProgressReporter::new(report, blocks.len()));
 
     let copier = ThreadedCopier::new(copier);
     let copy_thread = copier.run(rx, progress);

--- a/src/commands/cache_metadata_size.rs
+++ b/src/commands/cache_metadata_size.rs
@@ -121,7 +121,7 @@ impl CacheMetadataSizeCommand {
                 return Err(anyhow!("pool size must be larger than block size"));
             }
 
-            div_up(device_size, block_size as u64)
+            div_up(device_size, block_size)
         } else {
             return Err(anyhow!(
                 "Please specify either --device-size and --block-size, or --nr-blocks."

--- a/src/copier/sync_copier.rs
+++ b/src/copier/sync_copier.rs
@@ -162,7 +162,7 @@ impl<T: ReadBlocks + WriteBlocks + Send> SyncCopier<T> {
             match results {
                 Ok(results) => {
                     for (i, v) in results.iter().enumerate() {
-                        let index = op.indexes[i as usize];
+                        let index = op.indexes[i];
                         if v.is_ok() {
                             success_bits.insert(index as u32);
                         }
@@ -227,7 +227,7 @@ impl<T: ReadBlocks + WriteBlocks + Send> SyncCopier<T> {
             match results {
                 Ok(results) => {
                     for (i, v) in results.iter().enumerate() {
-                        let index = op.indexes[i as usize];
+                        let index = op.indexes[i];
                         if v.is_ok() {
                             success_bits.insert(index as u32);
                         }
@@ -310,15 +310,15 @@ impl<T: ReadBlocks + WriteBlocks + Send + 'static> Copier for SyncCopier<T> {
                 }
 
                 let mut stats = stats.write().unwrap();
-                stats.nr_copied += write_success.len() as u64;
+                stats.nr_copied += write_success.len();
                 progress.update(&stats);
             })
         };
 
         // read loop
         let chunk_size = self.buffer_size / self.block_size;
-        for chunk in ops.chunks(chunk_size as usize) {
-            let buffer_size = chunk.len() * self.block_size as usize;
+        for chunk in ops.chunks(chunk_size) {
+            let buffer_size = chunk.len() * self.block_size;
             let ops: Vec<CopyOp> = chunk.to_vec();
             let buffer = Buffer::new(buffer_size, 4096);
             let read_success = Self::do_reads(

--- a/src/era/dump.rs
+++ b/src/era/dump.rs
@@ -281,7 +281,7 @@ pub fn dump_metadata(
 
     let writesets = get_writesets_ordered(engine.clone(), sb, repair)?;
     for (era, ws) in writesets.iter() {
-        dump_writeset(engine.clone(), out, *era as u32, ws, repair)?;
+        dump_writeset(engine.clone(), out, *era, ws, repair)?;
     }
 
     out.era_b().context(OutputError)?;

--- a/src/io_engine/spindle.rs
+++ b/src/io_engine/spindle.rs
@@ -47,7 +47,7 @@ fn unpack_block(z: &[u8], loc: u64) -> Result<Block> {
     // FIXME: remove this copy
     let b = Block::new(loc);
     let mut c = std::io::Cursor::new(z);
-    let data = crate::pack::vm::unpack(&mut c, BLOCK_SIZE as usize)?;
+    let data = crate::pack::vm::unpack(&mut c, BLOCK_SIZE)?;
     unsafe {
         std::ptr::copy(data.as_ptr(), b.get_raw_ptr(), BLOCK_SIZE);
     }

--- a/src/io_engine/utils.rs
+++ b/src/io_engine/utils.rs
@@ -49,11 +49,11 @@ impl<T: VectoredIo> ReadBlocks for VectoredBlockIo<T> {
         while remaining > 0 {
             match self.dev.read_vectored_at(os_bufs, pos) {
                 Ok(n) => {
-                    remaining -= n as usize;
+                    remaining -= n;
                     pos += n as u64;
-                    assert_eq!(n as usize % block_size, 0);
-                    os_bufs = &mut os_bufs[(n as usize / block_size)..];
-                    for _ in 0..(n as usize / block_size) {
+                    assert_eq!(n % block_size, 0);
+                    os_bufs = &mut os_bufs[(n / block_size)..];
+                    for _ in 0..(n / block_size) {
                         results.push(Ok(()));
                     }
                 }
@@ -86,11 +86,11 @@ impl<T: VectoredIo> WriteBlocks for VectoredBlockIo<T> {
 
         while remaining > 0 {
             if let Ok(n) = self.dev.write_vectored_at(os_bufs, pos) {
-                remaining -= n as usize;
+                remaining -= n;
                 pos += n as u64;
-                assert_eq!(n as usize % block_size, 0);
-                os_bufs = &os_bufs[(n as usize / block_size)..];
-                for _ in 0..(n as usize / block_size) {
+                assert_eq!(n % block_size, 0);
+                os_bufs = &os_bufs[(n / block_size)..];
+                for _ in 0..(n / block_size) {
                     results.push(Ok(()));
                 }
             } else {

--- a/src/io_engine/utils/tests.rs
+++ b/src/io_engine/utils/tests.rs
@@ -86,10 +86,7 @@ impl<T: ReadBlocks + WriteBlocks, V: Validator> ReadWriteTest<T, V> {
 
     fn test_read(&self, blocks: Range<u64>) {
         let buf = Buffer::new(self.block_size * length(&blocks) as usize, 4096);
-        let mut bufs: Vec<&mut [u8]> = buf
-            .get_data()
-            .chunks_mut(self.block_size as usize)
-            .collect();
+        let mut bufs: Vec<&mut [u8]> = buf.get_data().chunks_mut(self.block_size).collect();
         let pos = self.offset + blocks.start * self.block_size as u64;
         let ret = self.dev.read_blocks(&mut bufs, pos);
         assert!(ret.is_ok());
@@ -98,7 +95,7 @@ impl<T: ReadBlocks + WriteBlocks, V: Validator> ReadWriteTest<T, V> {
 
     fn test_write(&self, blocks: Range<u64>) {
         let buf = Buffer::new(self.block_size * length(&blocks) as usize, 4096);
-        let bufs: Vec<&[u8]> = buf.get_data().chunks(self.block_size as usize).collect();
+        let bufs: Vec<&[u8]> = buf.get_data().chunks(self.block_size).collect();
         let pos = self.offset + blocks.start * self.block_size as u64;
         let ret = self.dev.write_blocks(&bufs, pos);
         assert!(ret.is_ok());

--- a/src/pack/toplevel.rs
+++ b/src/pack/toplevel.rs
@@ -191,7 +191,7 @@ where
 
 fn get_nr_blocks(path: &Path) -> io::Result<u64> {
     let len = file_utils::file_size(path)?;
-    Ok(len / (BLOCK_SIZE as u64))
+    Ok(len / BLOCK_SIZE)
 }
 
 fn read_blocks<R>(rdr: &mut R, b: u64, count: u64) -> io::Result<Vec<u8>>

--- a/src/pdata/array_builder/test_utils.rs
+++ b/src/pdata/array_builder/test_utils.rs
@@ -48,7 +48,7 @@ impl ArrayLayout {
         let nr_leaves = self.block_tree.nr_leaves();
         assert!(leaf_idx <= nr_leaves);
 
-        if leaf_idx as u64 == nr_leaves {
+        if leaf_idx == nr_leaves {
             self.nr_array_blocks()
         } else {
             self.block_tree.leaves()[leaf_idx as usize].entries_begin

--- a/src/pdata/array_walker.rs
+++ b/src/pdata/array_walker.rs
@@ -140,7 +140,7 @@ impl<'a, V: Unpack> NodeVisitor<u64> for BlockValueVisitor<'a, V> {
 
 impl ArrayWalker {
     pub fn new(engine: Arc<dyn IoEngine + Send + Sync>, ignore_non_fatal: bool) -> ArrayWalker {
-        let nr_blocks = engine.get_nr_blocks() as u64;
+        let nr_blocks = engine.get_nr_blocks();
         let r: ArrayWalker = ArrayWalker {
             engine,
             sm: Arc::new(Mutex::new(RestrictedSpaceMap::new(nr_blocks))),

--- a/src/pdata/bitset.rs
+++ b/src/pdata/bitset.rs
@@ -61,7 +61,7 @@ impl BitsetVisitor {
 impl ArrayVisitor<u64> for BitsetVisitor {
     fn visit(&self, index: u64, b: ArrayBlock<u64>) -> array::Result<()> {
         let mut begin = (index as usize * (b.header.max_entries as usize)) << 6;
-        if begin >= self.nr_bits as usize {
+        if begin >= self.nr_bits {
             return Err(array::value_err(format!(
                 "bitset size exceeds limit: {} bits",
                 self.nr_bits
@@ -69,7 +69,7 @@ impl ArrayVisitor<u64> for BitsetVisitor {
         }
 
         for bits in b.values.iter() {
-            let end: usize = std::cmp::min(begin + 64, self.nr_bits as usize);
+            let end: usize = std::cmp::min(begin + 64, self.nr_bits);
 
             let mut mask = 1;
             let mut extracted_bits = self.bits.lock().unwrap();

--- a/src/pdata/btree.rs
+++ b/src/pdata/btree.rs
@@ -258,7 +258,7 @@ pub fn pack_node<W: WriteBytesExt, V: Pack + Unpack>(node: &Node<V>, w: &mut W) 
 
 pub fn calc_max_entries<V: Unpack>() -> usize {
     let elt_size = 8 + V::disk_size() as usize;
-    let total = ((BLOCK_SIZE - NodeHeader::disk_size() as usize) / elt_size) as usize;
+    let total = (BLOCK_SIZE - NodeHeader::disk_size() as usize) / elt_size;
     total / 3 * 3
 }
 

--- a/src/pdata/btree_error.rs
+++ b/src/pdata/btree_error.rs
@@ -232,11 +232,11 @@ pub fn encode_node_path(path: &[u64]) -> String {
     // special case this.
     if !path.is_empty() && path[0] == 0 {
         let count = ((path.len() as u8) - 1) << 1;
-        cursor.write_u8(count as u8).unwrap();
+        cursor.write_u8(count).unwrap();
         vm::pack_u64s(&mut cursor, &path[1..]).unwrap();
     } else {
         let count = ((path.len() as u8) << 1) | 1;
-        cursor.write_u8(count as u8).unwrap();
+        cursor.write_u8(count).unwrap();
         vm::pack_u64s(&mut cursor, path).unwrap();
     }
 

--- a/src/pdata/space_map/base.rs
+++ b/src/pdata/space_map/base.rs
@@ -156,7 +156,7 @@ where
     }
 
     fn get_alloc_begin(&self) -> Result<u64> {
-        Ok(self.alloc_begin as u64)
+        Ok(self.alloc_begin)
     }
 }
 

--- a/src/pdata/space_map/common.rs
+++ b/src/pdata/space_map/common.rs
@@ -227,7 +227,7 @@ pub fn write_common(
                 1 => Small(1),
                 2 => Small(2),
                 _ => {
-                    overflow_builder.push_value(w, b as u64, rc)?;
+                    overflow_builder.push_value(w, b, rc)?;
                     Overflow
                 }
             };
@@ -309,7 +309,7 @@ pub fn write_metadata_common(w: &mut WriteBatcher) -> anyhow::Result<(Vec<IndexE
                     if i == none_free_before {
                         none_free_before = i + 1;
                     }
-                    overflow_builder.push_value(w, b as u64, rc)?;
+                    overflow_builder.push_value(w, b, rc)?;
                     Overflow
                 }
             };

--- a/src/thin/check.rs
+++ b/src/thin/check.rs
@@ -379,16 +379,15 @@ fn read_internal_nodes(
 
     // FIXME: make get-depth more resilient
     let mut path = Vec::new();
-    let depth;
-    if let Ok(d) = get_depth(ctx, &mut path, root as u64, true) {
-        depth = d;
+    let depth = if let Ok(d) = get_depth(ctx, &mut path, root as u64, true) {
+        d
     } else {
         return;
-    }
+    };
 
     if depth == 0 {
         // The root will be skipped if it is a confirmed internal
-        let _ = nodes.insert_leaf(root as u32);
+        let _ = nodes.insert_leaf(root);
         return;
     }
 

--- a/src/thin/ls.rs
+++ b/src/thin/ls.rs
@@ -524,16 +524,15 @@ fn read_internal_nodes(
 
     // FIXME: make get-depth more resilient
     let mut path = Vec::new();
-    let depth;
-    if let Ok(d) = get_depth(ctx, &mut path, root as u64, true) {
-        depth = d;
+    let depth = if let Ok(d) = get_depth(ctx, &mut path, root as u64, true) {
+        d
     } else {
         return;
-    }
+    };
 
     if depth == 0 {
         // The root will be skipped if it is a confirmed internal
-        let _ = nodes.insert_leaf(root as u32);
+        let _ = nodes.insert_leaf(root);
         return;
     }
 

--- a/src/thin/metadata.rs
+++ b/src/thin/metadata.rs
@@ -137,7 +137,7 @@ pub fn build_metadata_with_dev(
     let defs = Vec::new();
     let mut devs = Vec::new();
     for (thin_id, (_path, root)) in roots {
-        let id = thin_id as u64;
+        let id = thin_id;
         let detail = details.get(&id).expect("couldn't find device details");
         let es = entry_map.get(&root).unwrap();
         let kr = KeyRange::new(); // FIXME: finish

--- a/src/thin/restore.rs
+++ b/src/thin/restore.rs
@@ -206,7 +206,7 @@ impl<'a> Restorer<'a> {
             flags: SuperblockFlags { needs_check: false },
             block: SUPERBLOCK_LOCATION,
             version: 2,
-            time: src_sb.time as u32,
+            time: src_sb.time,
             transaction_id: src_sb.transaction,
             metadata_snap: 0,
             data_sm_root,
@@ -277,8 +277,8 @@ impl<'a> MetadataVisitor for Restorer<'a> {
         self.current_dev = Some(DeviceDetail {
             mapped_blocks: d.mapped_blocks,
             transaction_id: d.transaction,
-            creation_time: d.creation_time as u32,
-            snapshotted_time: d.snap_time as u32,
+            creation_time: d.creation_time,
+            snapshotted_time: d.snap_time,
         });
         self.in_section = Section::Device;
         self.begin_section(MappedSection::Dev(d.dev_id))

--- a/src/thin/trim.rs
+++ b/src/thin/trim.rs
@@ -148,10 +148,7 @@ fn read_bitmaps(engine: Arc<dyn IoEngine + Send + Sync>, bitmap_root: u64) -> Re
     let mut path = vec![0];
     let entries = btree_to_map::<IndexEntry>(&mut path, engine.clone(), false, bitmap_root)?;
 
-    let blocknr = entries
-        .iter()
-        .map(|(_, ie)| ie.blocknr)
-        .collect::<Vec<u64>>();
+    let blocknr = entries.values().map(|ie| ie.blocknr).collect::<Vec<u64>>();
     let blocks = engine.read_many(&blocknr[..])?;
     let mut bitmaps = Vec::new();
     for b in blocks {

--- a/tests/common/output_option.rs
+++ b/tests/common/output_option.rs
@@ -79,6 +79,12 @@ pub fn test_unwritable_output_file<'a, P>() -> Result<()>
 where
     P: OutputProgram<'a>,
 {
+    unsafe {
+        if libc::getuid() == 0 {
+            return Ok(());
+        }
+    }
+
     let mut td = TestDir::new()?;
     let input = P::mk_valid_input(&mut td)?;
 

--- a/tests/common/thin_xml_generator.rs
+++ b/tests/common/thin_xml_generator.rs
@@ -495,7 +495,7 @@ fn apply_snap_runs(
     Ok(runs)
 }
 
-// Snapshots share mappings, not neccessarily the entire ranges.
+// Snapshots share mappings, not necessarily the entire ranges.
 pub struct SnapS {
     pub len: u64,
     pub nr_snaps: u32,

--- a/tests/thin_check.rs
+++ b/tests/thin_check.rs
@@ -573,7 +573,7 @@ fn offline_check_should_examine_devices_with_reused_id() -> Result<()> {
 }
 
 #[test]
-fn offline_check_metadata_with_resued_id_should_success() -> Result<()> {
+fn offline_check_metadata_with_reused_id_should_success() -> Result<()> {
     let mut td = TestDir::new()?;
     let md = prep_metadata_from_file(&mut td, "tmeta_device_id_reuse.pack")?;
     run_ok(thin_check_cmd(args![&md]))?;

--- a/tests/thin_shrink.rs
+++ b/tests/thin_shrink.rs
@@ -274,7 +274,7 @@ fn create_data_file(data_path: &Path, xml_path: &Path) -> Result<()> {
     let input = OpenOptions::new().read(true).write(false).open(xml_path)?;
 
     let sb = xml::read_superblock(input)?;
-    let nr_blocks = sb.nr_data_blocks as u64;
+    let nr_blocks = sb.nr_data_blocks;
     let block_size = sb.data_block_size as u64 * 512;
 
     let _file = file_utils::create_sized_file(data_path, nr_blocks * block_size)?;


### PR DESCRIPTION
- crc32c: Apply the patches from pr#35 to fix the endianness issue
- Fix the output file permission test