### PR TITLE
Fix a thin_dump regression and other minor issues

### DIFF
--- a/src/commands/thin_explore.rs
+++ b/src/commands/thin_explore.rs
@@ -206,7 +206,7 @@ impl<'a> StatefulWidget for SBWidget<'a> {
         let details_root = vec!["details root".to_string(), format!("{}", sb.details_root)];
         let data_block_size = vec![
             "data block size".to_string(),
-            format!("{}k", sb.data_block_size * 2),
+            format!("{}k", sb.data_block_size / 2),
         ];
 
         let table = Table::new(vec![

--- a/src/commands/thin_explore.rs
+++ b/src/commands/thin_explore.rs
@@ -34,6 +34,7 @@ use crate::commands::Command;
 use crate::io_engine::*;
 use crate::pdata::btree;
 use crate::pdata::btree_error;
+use crate::pdata::space_map::common::SMRoot;
 use crate::pdata::unpack::*;
 use crate::thin::block_time::*;
 use crate::thin::device_detail::*;
@@ -159,7 +160,7 @@ impl<'a> StatefulWidget for SBWidget<'a> {
     fn render(self, area: Rect, buf: &mut Buffer, state: &mut ListState) {
         let chunks = Layout::default()
             .direction(Direction::Vertical)
-            .constraints([Constraint::Min(10), Constraint::Percentage(80)].as_ref())
+            .constraints([Constraint::Min(18), Constraint::Percentage(80)].as_ref())
             .split(area);
 
         let sb = self.sb;
@@ -180,6 +181,27 @@ impl<'a> StatefulWidget for SBWidget<'a> {
                 format!("{}", sb.metadata_snap)
             },
         ];
+        let metadata_root = unpack::<SMRoot>(&sb.metadata_sm_root[0..]).unwrap();
+        let data_root = unpack::<SMRoot>(&sb.data_sm_root[0..]).unwrap();
+        let metadata_allocated = vec![
+            "metadata allocated".to_string(),
+            format!("{}/{}", metadata_root.nr_allocated, metadata_root.nr_blocks),
+        ];
+        let meta_sm_roots = vec![
+            "metadata roots".to_string(),
+            format!(
+                "[{}, {}]",
+                metadata_root.bitmap_root, metadata_root.ref_count_root
+            ),
+        ];
+        let data_allocated = vec![
+            "data allocated".to_string(),
+            format!("{}/{}", data_root.nr_allocated, data_root.nr_blocks),
+        ];
+        let data_sm_roots = vec![
+            "data roots".to_string(),
+            format!("[{}, {}]", data_root.bitmap_root, data_root.ref_count_root),
+        ];
         let mapping_root = vec!["mapping root".to_string(), format!("{}", sb.mapping_root)];
         let details_root = vec!["details root".to_string(), format!("{}", sb.details_root)];
         let data_block_size = vec![
@@ -195,6 +217,10 @@ impl<'a> StatefulWidget for SBWidget<'a> {
             Row::new(time),
             Row::new(transaction_id),
             Row::new(metadata_snap),
+            Row::new(metadata_allocated),
+            Row::new(meta_sm_roots),
+            Row::new(data_allocated),
+            Row::new(data_sm_roots),
             Row::new(mapping_root),
             Row::new(details_root),
             Row::new(data_block_size),

--- a/src/commands/thin_stat.rs
+++ b/src/commands/thin_stat.rs
@@ -54,6 +54,7 @@ impl<'a> Command<'a> for ThinStatCommand {
             op: match matches.value_of("OP") {
                 Some("data_blocks") => StatOp::DataBlockRefCounts,
                 Some("metadata_blocks") => StatOp::MetadataBlockRefCounts,
+                Some("data_run_len") => StatOp::DataRunLength,
                 _ => return exitcode::USAGE,
             },
         };

--- a/src/commands/utils.rs
+++ b/src/commands/utils.rs
@@ -139,7 +139,11 @@ where
 
 pub fn to_exit_code<T>(report: &Report, result: anyhow::Result<T>) -> exitcode::ExitCode {
     if let Err(e) = result {
-        report.fatal(&format!("{}", e));
+        if e.chain().len() > 1 {
+            report.fatal(&format!("{}: {}", e, e.root_cause()));
+        } else {
+            report.fatal(&format!("{}", e));
+        }
 
         // FIXME: we need a way of getting more meaningful error codes
         exitcode::USAGE

--- a/src/thin/dump.rs
+++ b/src/thin/dump.rs
@@ -25,16 +25,16 @@ use crate::thin::xml;
 
 //------------------------------------------
 
-struct RunBuilder {
+pub struct RunBuilder {
     run: Option<ir::Map>,
 }
 
 impl RunBuilder {
-    fn new() -> RunBuilder {
+    pub fn new() -> RunBuilder {
         RunBuilder { run: None }
     }
 
-    fn next(&mut self, thin_block: u64, data_block: u64, time: u32) -> Option<ir::Map> {
+    pub fn next(&mut self, thin_block: u64, data_block: u64, time: u32) -> Option<ir::Map> {
         use ir::Map;
 
         match self.run {
@@ -71,8 +71,14 @@ impl RunBuilder {
         }
     }
 
-    fn complete(&mut self) -> Option<ir::Map> {
+    pub fn complete(&mut self) -> Option<ir::Map> {
         self.run.take()
+    }
+}
+
+impl Default for RunBuilder {
+    fn default() -> Self {
+        Self::new()
     }
 }
 

--- a/src/thin/stat.rs
+++ b/src/thin/stat.rs
@@ -211,9 +211,7 @@ pub struct ThinStatOpts<'a> {
 }
 
 pub fn stat(opts: ThinStatOpts) -> Result<()> {
-    let engine = EngineBuilder::new(opts.input, &opts.engine_opts)
-        .write(true)
-        .build()?;
+    let engine = EngineBuilder::new(opts.input, &opts.engine_opts).build()?;
 
     match opts.op {
         StatOp::DataBlockRefCounts => print_data_blocks_histogram(engine)?,


### PR DESCRIPTION
- Fix a regression in thin_dump causing that it cannot keep shared defs with only one predecessor
- Improve error message display
- Minor fixes and enhancements for development tools