### PR TITLE
[build] fix build on musl

### DIFF
--- a/src/file_utils.rs
+++ b/src/file_utils.rs
@@ -55,8 +55,14 @@ fn get_device_size<P: AsRef<Path>>(path: P) -> io::Result<u64> {
     let file = File::open(path.as_ref())?;
     let fd = file.as_raw_fd();
     let mut cap = 0u64;
+
+    #[cfg(target_env = "musl")]
+    type RequestType = libc::c_int;
+    #[cfg(not(target_env = "musl"))]
+    type RequestType = libc::c_ulong;
+
     unsafe {
-        if libc::ioctl(fd, BLKGETSIZE64 as libc::c_ulong, &mut cap) == 0 {
+        if libc::ioctl(fd, BLKGETSIZE64 as RequestType, &mut cap) == 0 {
             Ok(cap)
         } else {
             Err(io::Error::last_os_error())

--- a/src/thin/trim.rs
+++ b/src/thin/trim.rs
@@ -134,8 +134,13 @@ impl<'a> Iterator for RangeIterator<'a> {
 
 const BLKDISCARD: u32 = 0x1277;
 fn ioctl_blkdiscard(fd: i32, range: &[u64; 2]) -> std::io::Result<()> {
+    #[cfg(target_env = "musl")]
+    type RequestType = libc::c_int;
+    #[cfg(not(target_env = "musl"))]
+    type RequestType = libc::c_ulong;
+
     unsafe {
-        if libc::ioctl(fd, BLKDISCARD as libc::c_ulong, range) == 0 {
+        if libc::ioctl(fd, BLKDISCARD as RequestType, range) == 0 {
             Ok(())
         } else {
             Err(std::io::Error::last_os_error())


### PR DESCRIPTION
Before this PR, the build would fail with this error:
```
error[E0308]: mismatched types
   --> src/file_utils.rs:59:28
    |
59  |         if libc::ioctl(fd, BLKGETSIZE64 as libc::c_ulong, &mut cap) == 0 {
    |            -----------     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `i32`, found `u32`
    |            |
    |            arguments to this function are incorrect
    |
note: function defined here
   --> /host/cargo/registry/src/index.crates.io-6f17d22bba15001f/libc-0.2.142/src/unix/linux_like/linux/musl/mod.rs:739:12
    |
739 |     pub fn ioctl(fd: ::c_int, request: ::c_int, ...) -> ::c_int;
    |            ^^^^^
help: you can convert a `u32` to an `i32` and panic if the converted value doesn't fit
    |
59  |         if libc::ioctl(fd, (BLKGETSIZE64 as libc::c_ulong).try_into().unwrap(), &mut cap) == 0 {
    |                            +                             +++++++++++++++++++++

error[E0308]: mismatched types
   --> src/thin/trim.rs:138:28
    |
138 |         if libc::ioctl(fd, BLKDISCARD as libc::c_ulong, range) == 0 {
    |            -----------     ^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `i32`, found `u32`
    |            |
    |            arguments to this function are incorrect
    |
note: function defined here
   --> /host/cargo/registry/src/index.crates.io-6f17d22bba15001f/libc-0.2.142/src/unix/linux_like/linux/musl/mod.rs:739:12
    |
739 |     pub fn ioctl(fd: ::c_int, request: ::c_int, ...) -> ::c_int;
    |            ^^^^^
help: you can convert a `u32` to an `i32` and panic if the converted value doesn't fit
    |
138 |         if libc::ioctl(fd, (BLKDISCARD as libc::c_ulong).try_into().unwrap(), range) == 0 {
    |                            +                           +++++++++++++++++++++

For more information about this error, try `rustc --explain E0308`.
```
