### PR TITLE
[build] allow overriding PDATA_TOOLS in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 V=@
 
-PDATA_TOOLS=\
+PDATA_TOOLS:=\
 	target/release/pdata_tools
 
 $(PDATA_TOOLS):


### PR DESCRIPTION
Some distros, such as Void Linux, build binaries not to `target/release`, but to `target/${RUST_TARGET}/release`.
