### PR TITLE
Replace LFS functions

### DIFF
--- a/src/file_utils.rs
+++ b/src/file_utils.rs
@@ -11,18 +11,18 @@ fn test_bit(mode: u32, flag: u32) -> bool {
     (mode & libc::S_IFMT) == flag
 }
 
-fn is_file_or_blk_(info: &libc::stat64) -> bool {
+fn is_file_or_blk_(info: &libc::stat) -> bool {
     test_bit(info.st_mode, libc::S_IFBLK) || test_bit(info.st_mode, libc::S_IFREG)
 }
 
 // wrapper of libc::stat64
-fn libc_stat64(path: &Path) -> io::Result<libc::stat64> {
+fn libc_stat64(path: &Path) -> io::Result<libc::stat> {
     let c_path = std::ffi::CString::new(path.as_os_str().as_bytes())
         .map_err(|e| io::Error::new(io::ErrorKind::InvalidInput, e.to_string()))?;
 
     unsafe {
-        let mut st: libc::stat64 = std::mem::zeroed();
-        let r = libc::stat64(c_path.as_ptr(), &mut st);
+        let mut st: libc::stat = std::mem::zeroed();
+        let r = libc::stat(c_path.as_ptr(), &mut st);
         if r == 0 {
             Ok(st)
         } else {

--- a/src/io_engine/base.rs
+++ b/src/io_engine/base.rs
@@ -115,7 +115,7 @@ pub trait VectoredIo {
 
 fn read_vectored_at(file: &File, bufs: &mut [libc::iovec], pos: u64) -> io::Result<usize> {
     let ptr = bufs.as_ptr();
-    let ret = match unsafe { libc::preadv64(file.as_raw_fd(), ptr, bufs.len() as i32, pos as i64) }
+    let ret = match unsafe { libc::preadv(file.as_raw_fd(), ptr, bufs.len() as i32, pos as i64) }
     {
         -1 => return Err(io::Error::last_os_error()),
         n => n,
@@ -125,7 +125,7 @@ fn read_vectored_at(file: &File, bufs: &mut [libc::iovec], pos: u64) -> io::Resu
 
 fn write_vectored_at(file: &File, bufs: &[libc::iovec], pos: u64) -> io::Result<usize> {
     let ptr = bufs.as_ptr();
-    let ret = match unsafe { libc::pwritev64(file.as_raw_fd(), ptr, bufs.len() as i32, pos as i64) }
+    let ret = match unsafe { libc::pwritev(file.as_raw_fd(), ptr, bufs.len() as i32, pos as i64) }
     {
         -1 => return Err(io::Error::last_os_error()),
         n => n,


### PR DESCRIPTION
The original functions are able to consume 64bit off_t now a days therefore *64 equivalents can be replaced, as a side it fixes build with musl.

Upstream-Status: Pending