### PR TITLE
Improve cache_check auto-repair policies

### DIFF
--- a/src/bin/pdata_tools_dev.rs
+++ b/src/bin/pdata_tools_dev.rs
@@ -13,6 +13,7 @@ fn register_commands<'a>() -> Vec<Box<dyn Command<'a>>> {
     vec![
         Box::new(era_generate_metadata::EraGenerateMetadataCommand),
         Box::new(cache_generate_metadata::CacheGenerateMetadataCommand),
+        Box::new(cache_generate_damage::CacheGenerateDamageCommand),
         Box::new(thin_explore::ThinExploreCommand),
         Box::new(thin_generate_metadata::ThinGenerateMetadataCommand),
         Box::new(thin_generate_damage::ThinGenerateDamageCommand),

--- a/src/cache/check.rs
+++ b/src/cache/check.rs
@@ -236,7 +236,6 @@ impl ArrayVisitor<Hint> for HintChecker {
 
 //------------------------------------------
 
-// TODO: clear_needs_check, auto_repair
 pub struct CacheCheckOptions<'a> {
     pub dev: &'a Path,
     pub engine_opts: EngineOptions,
@@ -383,7 +382,7 @@ pub fn check(opts: CacheCheckOptions) -> anyhow::Result<()> {
     )?;
 
     if !metadata_leaks.is_empty() {
-        if opts.auto_repair {
+        if opts.auto_repair || opts.clear_needs_check {
             ctx.report.warning("Repairing metadata leaks.");
             repair_space_map(ctx.engine.clone(), metadata_leaks, metadata_sm.clone())?;
         } else if !opts.ignore_non_fatal {

--- a/src/cache/damage_generator.rs
+++ b/src/cache/damage_generator.rs
@@ -1,0 +1,42 @@
+use anyhow::Result;
+use std::path::Path;
+
+use crate::cache::superblock::*;
+use crate::commands::engine::*;
+use crate::devtools::damage_generator::*;
+use crate::pdata::space_map::common::*;
+use crate::pdata::unpack::unpack;
+
+//------------------------------------------
+
+pub enum DamageOp {
+    CreateMetadataLeaks {
+        nr_blocks: usize,
+        expected_rc: u32,
+        actual_rc: u32,
+    },
+}
+
+pub struct CacheDamageOpts<'a> {
+    pub engine_opts: EngineOptions,
+    pub op: DamageOp,
+    pub output: &'a Path,
+}
+
+pub fn damage_metadata(opts: CacheDamageOpts) -> Result<()> {
+    let engine = EngineBuilder::new(opts.output, &opts.engine_opts)
+        .write(true)
+        .build()?;
+    let sb = read_superblock(engine.as_ref(), SUPERBLOCK_LOCATION)?;
+    let sm_root = unpack::<SMRoot>(&sb.metadata_sm_root)?;
+
+    match opts.op {
+        DamageOp::CreateMetadataLeaks {
+            nr_blocks,
+            expected_rc,
+            actual_rc,
+        } => create_metadata_leaks(engine, sm_root, nr_blocks, expected_rc, actual_rc),
+    }
+}
+
+//------------------------------------------

--- a/src/cache/mod.rs
+++ b/src/cache/mod.rs
@@ -12,3 +12,6 @@ pub mod xml;
 
 #[cfg(feature = "devtools")]
 pub mod metadata_generator;
+
+#[cfg(feature = "devtools")]
+pub mod damage_generator;

--- a/src/commands/cache_generate_damage.rs
+++ b/src/commands/cache_generate_damage.rs
@@ -1,0 +1,106 @@
+use clap::{value_parser, Arg, ArgAction, ArgGroup};
+use std::path::Path;
+use std::process;
+
+use crate::cache::damage_generator::*;
+use crate::commands::engine::*;
+use crate::commands::utils::*;
+use crate::version::*;
+
+//------------------------------------------
+use crate::commands::Command;
+
+pub struct CacheGenerateDamageCommand;
+
+impl CacheGenerateDamageCommand {
+    fn cli(&self) -> clap::Command {
+        let cmd = clap::Command::new(self.name())
+            .next_display_order(None)
+            .version(crate::tools_version!())
+            .disable_version_flag(true)
+            .about("A tool for creating damages in cache metadata.")
+            .arg(
+                Arg::new("CREATE_METADATA_LEAKS")
+                    .help("Create leaked metadata blocks")
+                    .long("create-metadata-leaks")
+                    .action(ArgAction::SetTrue)
+                    .requires_all(["EXPECTED", "ACTUAL", "NR_BLOCKS"]),
+            )
+            // options
+            .arg(
+                Arg::new("EXPECTED")
+                    .help("The expected reference count of damaged blocks")
+                    .long("expected")
+                    .value_name("REFCONT")
+                    .value_parser(value_parser!(u32)),
+            )
+            .arg(
+                Arg::new("ACTUAL")
+                    .help("The actual reference count of damaged blocks")
+                    .long("actual")
+                    .value_name("REFCOUNT")
+                    .value_parser(value_parser!(u32)),
+            )
+            .arg(
+                Arg::new("NR_BLOCKS")
+                    .help("Specify the number of metadata blocks")
+                    .long("nr-blocks")
+                    .value_name("NUM")
+                    .value_parser(value_parser!(usize)),
+            )
+            .arg(
+                Arg::new("OUTPUT")
+                    .help("Specify the output device")
+                    .short('o')
+                    .long("output")
+                    .value_name("FILE")
+                    .required(true),
+            )
+            .group(
+                ArgGroup::new("commands")
+                    .args(["CREATE_METADATA_LEAKS"])
+                    .required(true),
+            );
+        engine_args(version_args(cmd))
+    }
+}
+
+impl<'a> Command<'a> for CacheGenerateDamageCommand {
+    fn name(&self) -> &'a str {
+        "cache_generate_damage"
+    }
+
+    fn run(&self, args: &mut dyn Iterator<Item = std::ffi::OsString>) -> exitcode::ExitCode {
+        let matches = self.cli().get_matches_from(args);
+        display_version(&matches);
+
+        let report = mk_report(false);
+
+        let engine_opts = parse_engine_opts(ToolType::Cache, &matches);
+        if engine_opts.is_err() {
+            return to_exit_code(&report, engine_opts);
+        }
+
+        let op = match matches.get_one::<clap::Id>("commands").unwrap().as_str() {
+            "CREATE_METADATA_LEAKS" => DamageOp::CreateMetadataLeaks {
+                nr_blocks: *matches.get_one::<usize>("NR_BLOCKS").unwrap(),
+                expected_rc: *matches.get_one::<u32>("EXPECTED").unwrap(),
+                actual_rc: *matches.get_one::<u32>("ACTUAL").unwrap(),
+            },
+            _ => {
+                eprintln!("unknown option");
+                process::exit(1);
+            }
+        };
+
+        let opts = CacheDamageOpts {
+            engine_opts: engine_opts.unwrap(),
+            op,
+            output: Path::new(matches.get_one::<String>("OUTPUT").unwrap()),
+        };
+
+        to_exit_code(&report, damage_metadata(opts))
+    }
+}
+
+//------------------------------------------

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -25,6 +25,8 @@ pub mod thin_trim;
 pub mod utils;
 
 #[cfg(feature = "devtools")]
+pub mod cache_generate_damage;
+#[cfg(feature = "devtools")]
 pub mod cache_generate_metadata;
 #[cfg(feature = "devtools")]
 pub mod era_generate_metadata;

--- a/src/devtools/damage_generator.rs
+++ b/src/devtools/damage_generator.rs
@@ -1,0 +1,155 @@
+use anyhow::{anyhow, Result};
+use rand::prelude::SliceRandom;
+use std::io::Cursor;
+
+use std::sync::Arc;
+
+use crate::checksum;
+
+use crate::io_engine::IoEngine;
+use crate::pdata::btree_walker::btree_to_map;
+use crate::pdata::space_map::common::*;
+use crate::pdata::space_map::metadata::*;
+use crate::pdata::unpack::{unpack, Pack};
+
+//------------------------------------------
+
+fn find_blocks_of_rc(
+    engine: Arc<dyn IoEngine + Send + Sync>,
+    sm_root: SMRoot,
+    ref_count: u32,
+) -> Result<Vec<u64>> {
+    let mut found = Vec::<u64>::new();
+    if ref_count < 3 {
+        let b = engine.read(sm_root.bitmap_root)?;
+        let entries = load_metadata_index(&b, sm_root.nr_blocks)?.indexes;
+        let bitmaps: Vec<u64> = entries.iter().map(|ie| ie.blocknr).collect();
+        let nr_bitmaps = bitmaps.len();
+
+        let rblocks = engine.read_many(&bitmaps)?;
+        let mut blocknr = 0;
+        for (idx, rb) in rblocks.into_iter().enumerate() {
+            if let Ok(b) = rb {
+                let bitmap = unpack::<Bitmap>(b.get_data())?;
+                let len = if idx == nr_bitmaps - 1 {
+                    (engine.get_nr_blocks() % ENTRIES_PER_BITMAP as u64) as usize
+                } else {
+                    ENTRIES_PER_BITMAP
+                };
+                for e in &bitmap.entries[..len] {
+                    if BitmapEntry::Small(ref_count as u8) == *e {
+                        found.push(blocknr);
+                    }
+                    blocknr += 1;
+                }
+            } else {
+                return Err(anyhow!("Cannot read bitmap: {}", rb.unwrap_err()));
+            }
+        }
+    } else {
+        let mut path = Vec::new();
+        let high_rc = btree_to_map::<u32>(&mut path, engine, false, sm_root.ref_count_root)?;
+        for (k, v) in high_rc.iter() {
+            if *v == ref_count {
+                found.push(*k);
+            }
+        }
+    }
+
+    Ok(found)
+}
+
+fn adjust_bitmap_entries(
+    engine: &dyn IoEngine,
+    sm_root: SMRoot,
+    blocks: &[u64],
+    ref_count: u32,
+) -> Result<()> {
+    let entry = if ref_count < 3 {
+        BitmapEntry::Small(ref_count as u8)
+    } else {
+        BitmapEntry::Overflow
+    };
+
+    let index_block = engine.read(sm_root.bitmap_root)?;
+    let entries = load_metadata_index(&index_block, sm_root.nr_blocks)?.indexes;
+
+    let bi = blocks_to_bitmaps(blocks);
+    let bitmaps: Vec<u64> = bi.iter().map(|i| entries[*i].blocknr).collect();
+
+    let rblocks = engine.read_many(&bitmaps)?;
+    let mut wblocks = Vec::new();
+    let mut blocks_iter = blocks.iter();
+    let mut block = blocks_iter.next();
+    for (rb, idx) in rblocks.into_iter().zip(bi) {
+        if let Ok(b) = rb {
+            let mut bitmap = unpack::<Bitmap>(b.get_data())?;
+            let high = (ENTRIES_PER_BITMAP * (idx + 1)) as u64;
+
+            while block.is_some() && *block.unwrap() < high {
+                let i = (*block.unwrap() % ENTRIES_PER_BITMAP as u64) as usize;
+                bitmap.entries[i] = entry;
+                block = blocks_iter.next();
+            }
+
+            let mut out = Cursor::new(b.get_data());
+            bitmap.pack(&mut out)?;
+            checksum::write_checksum(b.get_data(), checksum::BT::BITMAP)?;
+
+            wblocks.push(b);
+        } else {
+            return Err(anyhow!("Errors in reading bitmaps"));
+        }
+    }
+
+    let results = engine.write_many(&wblocks)?;
+    for ret in results {
+        if ret.is_err() {
+            return Err(anyhow!("Errors in writing bitmaps"));
+        }
+    }
+
+    Ok(())
+}
+
+pub fn create_metadata_leaks(
+    engine: Arc<dyn IoEngine + Send + Sync>,
+    sm_root: SMRoot,
+    nr_leaks: usize,
+    expected_rc: u32,
+    actual_rc: u32,
+) -> Result<()> {
+    let mut blocks = find_blocks_of_rc(engine.clone(), sm_root.clone(), expected_rc)?;
+    if blocks.len() < nr_leaks {
+        return Err(anyhow!(
+            "no sufficient blocks with ref counts {}",
+            expected_rc
+        ));
+    }
+
+    blocks.shuffle(&mut rand::thread_rng());
+    blocks.truncate(nr_leaks);
+    blocks.sort_unstable();
+
+    #[allow(clippy::if_same_then_else)]
+    if expected_rc > 2 {
+        if actual_rc > 2 {
+            // adjust mapped rc in ref count btree
+            todo!();
+        } else {
+            // 1. adjust_bitmap_entries(engine, sm_root, &blocks, actual_rc);
+            // 2. remove mappings from the ref count btree
+            // 3. update superblock
+            todo!();
+        }
+    } else if actual_rc > 2 {
+        // 1. adjust_bitmap_entries(engine, sm_root, &blocks, actual_rc);
+        // 2. insert mappings to the ref count btree
+        // 3. update superblock
+        todo!();
+    } else {
+        adjust_bitmap_entries(engine.as_ref(), sm_root, &blocks, actual_rc)
+    }
+}
+
+//------------------------------------------

--- a/src/devtools/mod.rs
+++ b/src/devtools/mod.rs
@@ -1,0 +1,2 @@
+#[cfg(feature = "devtools")]
+pub mod damage_generator;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,4 +31,7 @@ pub mod xml;
 #[cfg(any(test, feature = "devtools"))]
 pub mod random;
 
+#[cfg(feature = "devtools")]
+pub mod devtools;
+
 pub use utils::hashvec;

--- a/src/thin/damage_generator.rs
+++ b/src/thin/damage_generator.rs
@@ -1,159 +1,16 @@
-use anyhow::{anyhow, Result};
-use rand::prelude::SliceRandom;
-use std::io::Cursor;
+use anyhow::Result;
+
 use std::path::Path;
 use std::sync::Arc;
 
-use crate::checksum;
 use crate::commands::engine::*;
+use crate::devtools::damage_generator::*;
 use crate::io_engine::IoEngine;
-use crate::pdata::btree_walker::btree_to_map;
+
 use crate::pdata::space_map::common::*;
-use crate::pdata::space_map::metadata::*;
-use crate::pdata::unpack::{unpack, Pack};
+
+use crate::pdata::unpack::unpack;
 use crate::thin::superblock::*;
-
-//------------------------------------------
-
-fn find_blocks_of_rc(
-    engine: Arc<dyn IoEngine + Send + Sync>,
-    sm_root: SMRoot,
-    ref_count: u32,
-) -> Result<Vec<u64>> {
-    let mut found = Vec::<u64>::new();
-    if ref_count < 3 {
-        let b = engine.read(sm_root.bitmap_root)?;
-        let entries = load_metadata_index(&b, sm_root.nr_blocks)?.indexes;
-        let bitmaps: Vec<u64> = entries.iter().map(|ie| ie.blocknr).collect();
-        let nr_bitmaps = bitmaps.len();
-
-        let rblocks = engine.read_many(&bitmaps)?;
-        let mut blocknr = 0;
-        for (idx, rb) in rblocks.into_iter().enumerate() {
-            if let Ok(b) = rb {
-                let bitmap = unpack::<Bitmap>(b.get_data())?;
-                let len = if idx == nr_bitmaps - 1 {
-                    (engine.get_nr_blocks() % ENTRIES_PER_BITMAP as u64) as usize
-                } else {
-                    ENTRIES_PER_BITMAP
-                };
-                for e in &bitmap.entries[..len] {
-                    if BitmapEntry::Small(ref_count as u8) == *e {
-                        found.push(blocknr);
-                    }
-                    blocknr += 1;
-                }
-            } else {
-                return Err(anyhow!("Cannot read bitmap: {}", rb.unwrap_err()));
-            }
-        }
-    } else {
-        let mut path = Vec::new();
-        let high_rc = btree_to_map::<u32>(&mut path, engine, false, sm_root.ref_count_root)?;
-        for (k, v) in high_rc.iter() {
-            if *v == ref_count {
-                found.push(*k);
-            }
-        }
-    }
-
-    Ok(found)
-}
-
-//------------------------------------------
-
-fn adjust_bitmap_entries(
-    engine: &dyn IoEngine,
-    sm_root: SMRoot,
-    blocks: &[u64],
-    ref_count: u32,
-) -> Result<()> {
-    let entry = if ref_count < 3 {
-        BitmapEntry::Small(ref_count as u8)
-    } else {
-        BitmapEntry::Overflow
-    };
-
-    let index_block = engine.read(sm_root.bitmap_root)?;
-    let entries = load_metadata_index(&index_block, sm_root.nr_blocks)?.indexes;
-
-    let bi = blocks_to_bitmaps(blocks);
-    let bitmaps: Vec<u64> = bi.iter().map(|i| entries[*i].blocknr).collect();
-
-    let rblocks = engine.read_many(&bitmaps)?;
-    let mut wblocks = Vec::new();
-    let mut blocks_iter = blocks.iter();
-    let mut block = blocks_iter.next();
-    for (rb, idx) in rblocks.into_iter().zip(bi) {
-        if let Ok(b) = rb {
-            let mut bitmap = unpack::<Bitmap>(b.get_data())?;
-            let high = (ENTRIES_PER_BITMAP * (idx + 1)) as u64;
-
-            while block.is_some() && *block.unwrap() < high {
-                let i = (*block.unwrap() % ENTRIES_PER_BITMAP as u64) as usize;
-                bitmap.entries[i] = entry;
-                block = blocks_iter.next();
-            }
-
-            let mut out = Cursor::new(b.get_data());
-            bitmap.pack(&mut out)?;
-            checksum::write_checksum(b.get_data(), checksum::BT::BITMAP)?;
-
-            wblocks.push(b);
-        } else {
-            return Err(anyhow!("Errors in reading bitmaps"));
-        }
-    }
-
-    let results = engine.write_many(&wblocks)?;
-    for ret in results {
-        if ret.is_err() {
-            return Err(anyhow!("Errors in writing bitmaps"));
-        }
-    }
-
-    Ok(())
-}
-
-fn create_metadata_leaks(
-    engine: Arc<dyn IoEngine + Send + Sync>,
-    sm_root: SMRoot,
-    nr_leaks: usize,
-    expected_rc: u32,
-    actual_rc: u32,
-) -> Result<()> {
-    let mut blocks = find_blocks_of_rc(engine.clone(), sm_root.clone(), expected_rc)?;
-    if blocks.len() < nr_leaks {
-        return Err(anyhow!(
-            "no sufficient blocks with ref counts {}",
-            expected_rc
-        ));
-    }
-
-    blocks.shuffle(&mut rand::thread_rng());
-    blocks.truncate(nr_leaks);
-    blocks.sort_unstable();
-
-    #[allow(clippy::if_same_then_else)]
-    if expected_rc > 2 {
-        if actual_rc > 2 {
-            // adjust mapped rc in ref count btree
-            todo!();
-        } else {
-            // 1. adjust_bitmap_entries(engine, sm_root, &blocks, actual_rc);
-            // 2. remove mappings from the ref count btree
-            // 3. update superblock
-            todo!();
-        }
-    } else if actual_rc > 2 {
-        // 1. adjust_bitmap_entries(engine, sm_root, &blocks, actual_rc);
-        // 2. insert mappings to the ref count btree
-        // 3. update superblock
-        todo!();
-    } else {
-        adjust_bitmap_entries(engine.as_ref(), sm_root, &blocks, actual_rc)
-    }
-}
 
 //------------------------------------------
 

--- a/src/thin/delta.rs
+++ b/src/thin/delta.rs
@@ -107,9 +107,9 @@ impl NodeVisitor<BlockTime> for MappingRecorder {
     }
 }
 
-// The `time` field is not extracted for CoW indication. The mapped data block
-// does the job. i.e., the data block must be different if the mapping had been
-// CoW'ed.
+// In order to compare snapshots that are not derived from the same origin,
+// thin_delta compares mappings based on the data block addresses, thus the
+// mapping timestamps are not extracted.
 pub fn get_mappings(
     engine: Arc<dyn IoEngine + Send + Sync>,
     root: u64,

--- a/tests/cache_dump.rs
+++ b/tests/cache_dump.rs
@@ -115,3 +115,18 @@ fn dump_restore_cycle() -> Result<()> {
 
     Ok(())
 }
+
+//------------------------------------------
+// test no stderr on broken pipe errors
+
+#[test]
+fn no_stderr_on_broken_pipe_xml() -> Result<()> {
+    common::piping::test_no_stderr_on_broken_pipe::<CacheDump>(mk_valid_md, &[])
+}
+
+#[test]
+fn no_stderr_on_broken_fifo_xml() -> Result<()> {
+    common::piping::test_no_stderr_on_broken_fifo::<CacheDump>(mk_valid_md, &[])
+}
+
+//------------------------------------------

--- a/tests/common/cache.rs
+++ b/tests/common/cache.rs
@@ -36,6 +36,33 @@ pub fn mk_valid_md(td: &mut TestDir) -> Result<PathBuf> {
 
 //-----------------------------------------------
 
+pub fn generate_metadata_leaks(
+    md: &Path,
+    nr_blocks: u64,
+    expected: u32,
+    actual: u32,
+) -> Result<()> {
+    let nr_blocks_str = nr_blocks.to_string();
+    let expected_str = expected.to_string();
+    let actual_str = actual.to_string();
+    let args = args![
+        "-o",
+        &md,
+        "--create-metadata-leaks",
+        "--nr-blocks",
+        &nr_blocks_str,
+        "--expected",
+        &expected_str,
+        "--actual",
+        &actual_str
+    ];
+    run_ok(cache_generate_damage_cmd(args))?;
+
+    Ok(())
+}
+
+//-----------------------------------------------
+
 pub fn get_clean_shutdown(md: &Path) -> Result<bool> {
     use thinp::cache::superblock::*;
 
@@ -50,6 +77,12 @@ pub fn get_needs_check(md: &Path) -> Result<bool> {
     let engine = SyncIoEngine::new(md, false)?;
     let sb = read_superblock(&engine, SUPERBLOCK_LOCATION)?;
     Ok(sb.flags.needs_check)
+}
+
+pub fn unset_clean_shutdown(md: &Path) -> Result<()> {
+    let args = args!["-o", &md, "--set-clean-shutdown=false"];
+    run_ok(cache_generate_metadata_cmd(args))?;
+    Ok(())
 }
 
 pub fn set_needs_check(md: &Path) -> Result<()> {

--- a/tests/common/era.rs
+++ b/tests/common/era.rs
@@ -14,7 +14,7 @@ use crate::common::test_dir::TestDir;
 
 pub fn mk_valid_xml(td: &mut TestDir) -> Result<PathBuf> {
     let xml = td.mk_path("meta.xml");
-    let mut gen = CleanShutdownMeta::new(128, 256, 32, 4); // bs, nr_blocks, era, nr_wsets
+    let mut gen = CleanShutdownMeta::new(128, 512, 32, 4); // bs, nr_blocks, era, nr_wsets
     write_xml(&xml, &mut gen)?;
     Ok(xml)
 }
@@ -23,7 +23,7 @@ pub fn mk_valid_md(td: &mut TestDir) -> Result<PathBuf> {
     let xml = td.mk_path("meta.xml");
     let md = td.mk_path("meta.bin");
 
-    let mut gen = CleanShutdownMeta::new(128, 256, 32, 4);
+    let mut gen = CleanShutdownMeta::new(128, 512, 32, 4);
     write_xml(&xml, &mut gen)?;
 
     let _file = file_utils::create_sized_file(&md, 4096 * 4096);

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -10,6 +10,7 @@ pub mod era_xml_generator;
 pub mod fixture;
 pub mod input_arg;
 pub mod output_option;
+pub mod piping;
 pub mod process;
 pub mod program;
 pub mod target;

--- a/tests/common/piping.rs
+++ b/tests/common/piping.rs
@@ -1,0 +1,115 @@
+use anyhow::Result;
+use std::fs::OpenOptions;
+use std::path::PathBuf;
+
+use crate::args;
+use crate::common::program::*;
+use crate::common::test_dir::TestDir;
+
+//------------------------------------------
+
+pub fn test_no_stderr_on_broken_pipe<'a, P>(
+    prep_input: fn(&mut TestDir) -> Result<PathBuf>,
+    extra_args: &[&std::ffi::OsStr],
+) -> Result<()>
+where
+    P: InputProgram<'a>,
+{
+    use anyhow::ensure;
+
+    let mut td = TestDir::new()?;
+
+    // prepare the input to produce more than 64KB output (the default pipe buffer size),
+    // such that the program will be blocked on pipe write, then hits EPIPE.
+    let md = prep_input(&mut td)?;
+
+    let mut pipefd = [0i32; 2];
+    unsafe {
+        ensure!(libc::pipe2(pipefd.as_mut_slice().as_mut_ptr(), libc::O_CLOEXEC) == 0);
+        ensure!(libc::fcntl(pipefd[0], libc::F_SETPIPE_SZ, 65536) == 65536);
+    }
+
+    let mut args = args![&md].to_vec();
+    args.extend_from_slice(extra_args);
+    let cmd = P::cmd(args)
+        .to_expr()
+        .stdout_file(pipefd[1]) // this transfers ownership of the fd
+        .stderr_capture();
+    let handle = cmd.unchecked().start()?;
+
+    unsafe {
+        // read outputs from the program
+        let mut buf = vec![0; 128];
+        libc::read(pipefd[0], buf.as_mut_slice().as_mut_ptr().cast(), 128);
+        libc::close(pipefd[0]); // causing broken pipe
+    }
+
+    let output = handle.wait()?;
+    ensure!(!output.status.success());
+    ensure!(output.stderr.is_empty());
+
+    Ok(())
+}
+
+pub fn test_no_stderr_on_broken_fifo<'a, P>(
+    prep_input: fn(&mut TestDir) -> Result<PathBuf>,
+    extra_args: &[&std::ffi::OsStr],
+) -> Result<()>
+where
+    P: InputProgram<'a>,
+{
+    use anyhow::ensure;
+    use std::io::Read;
+    use std::os::fd::AsRawFd;
+    use std::os::unix::fs::OpenOptionsExt;
+
+    let mut td = TestDir::new()?;
+
+    // prepare the input to produce more than 64KB output (the default pipe buffer size),
+    // such that the program will be blocked on pipe write, then hits EPIPE.
+    let md = prep_input(&mut td)?;
+
+    let out_fifo = td.mk_path("out_fifo");
+    unsafe {
+        let c_str = std::ffi::CString::new(out_fifo.as_os_str().as_encoded_bytes()).unwrap();
+        ensure!(libc::mkfifo(c_str.as_ptr(), 0o666) == 0);
+    };
+
+    let mut fifo = OpenOptions::new()
+        .read(true)
+        .custom_flags(libc::O_CLOEXEC | libc::O_NONBLOCK)
+        .open(&out_fifo)?;
+    unsafe {
+        ensure!(libc::fcntl(fifo.as_raw_fd(), libc::F_SETPIPE_SZ, 65536) == 65536);
+        let new_flags = libc::O_RDONLY | libc::O_CLOEXEC;
+        ensure!(libc::fcntl(fifo.as_raw_fd(), libc::F_SETFL, new_flags) == 0);
+    }
+
+    let mut args = args![&md, "-o", &out_fifo].to_vec();
+    args.extend_from_slice(extra_args);
+    let cmd = P::cmd(args).to_expr().stderr_capture();
+    let handle = cmd.unchecked().start()?;
+
+    // wait for the fifo is ready
+    unsafe {
+        let mut pollfd = libc::pollfd {
+            fd: fifo.as_raw_fd(),
+            events: libc::POLLIN,
+            revents: 0,
+        };
+        ensure!(libc::poll(&mut pollfd, 1, 10000) == 1);
+    }
+
+    // read outputs from the program
+    let mut buf = vec![0; 128];
+    fifo.read_exact(&mut buf)?;
+    drop(fifo); // causing broken pipe
+
+    let output = handle.wait()?;
+    ensure!(!output.status.success());
+    ensure!(output.stderr.is_empty());
+
+    Ok(())
+}
+
+//------------------------------------------

--- a/tests/common/target.rs
+++ b/tests/common/target.rs
@@ -164,6 +164,14 @@ where
     rust_devel_cmd("cache_generate_metadata", args)
 }
 
+pub fn cache_generate_damage_cmd<I>(args: I) -> Command
+where
+    I: IntoIterator,
+    I::Item: Into<OsString>,
+{
+    rust_devel_cmd("cache_generate_damage", args)
+}
+
 pub fn cache_metadata_size_cmd<I>(args: I) -> Command
 where
     I: IntoIterator,

--- a/tests/era_dump.rs
+++ b/tests/era_dump.rs
@@ -119,3 +119,18 @@ fn dump_restore_cycle() -> Result<()> {
 
     Ok(())
 }
+
+//------------------------------------------
+// test no stderr on broken pipe errors
+
+#[test]
+fn no_stderr_on_broken_pipe_xml() -> Result<()> {
+    common::piping::test_no_stderr_on_broken_pipe::<EraDump>(mk_valid_md, &[])
+}
+
+#[test]
+fn no_stderr_on_broken_fifo_xml() -> Result<()> {
+    common::piping::test_no_stderr_on_broken_fifo::<EraDump>(mk_valid_md, &[])
+}
+
+//------------------------------------------


### PR DESCRIPTION
- Extend cache_check's --clear-needs-check-flag option to have auto-repair caps
- Add tests for cache_check --auto-repair and --clear-needs-check-flag
- Add broken pipe tests for cache_dump and era_dump