### PR TITLE
[thin_metadata_size] Reduce minimal block size to 4K

### DIFF
--- a/src/thin/metadata_size.rs
+++ b/src/thin/metadata_size.rs
@@ -8,7 +8,7 @@ use crate::thin::block_time::BlockTime;
 
 //------------------------------------------
 
-const MIN_DATA_BLOCK_SIZE: u64 = 65536;
+const MIN_DATA_BLOCK_SIZE: u64 = 4096;
 const MAX_DATA_BLOCK_SIZE: u64 = 1073741824;
 
 pub struct ThinMetadataSizeOptions {
@@ -17,12 +17,19 @@ pub struct ThinMetadataSizeOptions {
 }
 
 pub fn check_data_block_size(block_size: u64) -> Result<()> {
-    if block_size == 0 || (block_size & (MIN_DATA_BLOCK_SIZE - 1)) != 0 {
-        return Err(anyhow!("block size must be a multiple of 64 KiB"));
+    if block_size < MIN_DATA_BLOCK_SIZE || (block_size & (MIN_DATA_BLOCK_SIZE - 1)) != 0 {
+        return Err(anyhow!(
+            "block size - {} - must be a multiple of {} KiB",
+            block_size,
+            MIN_DATA_BLOCK_SIZE / 1024
+        ));
     }
 
     if block_size > MAX_DATA_BLOCK_SIZE {
-        return Err(anyhow!("maximum block size is 1 GiB"));
+        return Err(anyhow!(
+            "maximum block size is {} GiB",
+            block_size / 1024 / 1024
+        ));
     }
 
     Ok(())

--- a/tests/thin_metadata_size.rs
+++ b/tests/thin_metadata_size.rs
@@ -120,7 +120,7 @@ fn dev_size_and_block_size_succeeds() -> Result<()> {
 
 #[test]
 fn test_valid_block_sizes() -> Result<()> {
-    let block_sizes = [128, 256, 384, 2097152];
+    let block_sizes = [8, 16, 32, 64, 128, 256, 384, 2097152];
     for bs in block_sizes {
         let bs = bs.to_string();
         run_ok(thin_metadata_size_cmd(args![
@@ -137,7 +137,7 @@ fn test_valid_block_sizes() -> Result<()> {
 
 #[test]
 fn invalid_block_size_should_fail() -> Result<()> {
-    let block_sizes = [0, 64, 127, 2097153, 2097280, 4194304];
+    let block_sizes = [0, 4, 127, 2097153, 2097280, 4194304];
     for bs in block_sizes {
         let bs = bs.to_string();
         run_fail(thin_metadata_size_cmd(args![


### PR DESCRIPTION
Manpage and documentation recommend 64K block size. Older implemenation allowed smaller sizes than 64K.
Reduce limit to 4K, enforce block size is larger or equal to 4K.

Added unit test to confirm the change is taken into account.